### PR TITLE
Move modules from node-boot-oauth2-ui library to the web base

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6456,13 +6456,6 @@
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
     },
-    "nodeboot-oauth2-starter-ui": {
-      "version": "git+https://github.com/usil/nodeboot-oauth2-ui-starter-dist.git#190dbe4bfdce5042f4efe60eda2cafac03867ff9",
-      "from": "git+https://github.com/usil/nodeboot-oauth2-ui-starter-dist.git",
-      "requires": {
-        "tslib": "^2.3.0"
-      }
-    },
     "nodeboot-spa-server": {
       "version": "git+https://github.com/usil/nodeboot-spa-server.git#c41637e2b16db1b9be9af68c73d449ed8c7b60ae",
       "from": "git+https://github.com/usil/nodeboot-spa-server.git",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "dotenv": "16.0.0",
     "moment": "2.29.2",
     "ngx-clipboard": "15.0.1",
-    "nodeboot-oauth2-starter-ui": "git+https://github.com/usil/nodeboot-oauth2-ui-starter-dist.git",
     "rxjs": "7.4.0",
     "tslib": "2.3.0",
     "zone.js": "0.11.4"

--- a/src/app/dashboard/auth/application-resource/application-options/application-options.component.html
+++ b/src/app/dashboard/auth/application-resource/application-options/application-options.component.html
@@ -1,0 +1,57 @@
+<h2 mat-dialog-title>Resource options</h2>
+<form [formGroup]="addResourceOptionForm" (ngSubmit)="updateResourceOptions()">
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <div class="select-role">
+      <mat-form-field class="forms-field" appearance="fill">
+        <mat-label>New Option</mat-label>
+        <input matInput formControlName="name" name="name" />
+        <mat-hint>Resource option</mat-hint>
+      </mat-form-field>
+      <button
+        [disabled]="!addResourceOptionForm.valid"
+        type="button"
+        (click)="addOptionToList()"
+        mat-stroked-button
+      >
+        +
+      </button>
+    </div>
+    <div class="options-list-container">
+      <div *ngFor="let option of optionsList" class="roles-list">
+        <div class="role-title">
+          <h3>{{ option.allowed }}</h3>
+        </div>
+        <button
+          [disabled]="isBasicOption(option.allowed)"
+          (click)="removeFromOptionList(option)"
+          color="warn"
+          type="button"
+          mat-stroked-button
+        >
+          -
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!addResourceOptionForm.valid || optionsList.length === 0"
+      color="primary"
+      mat-flat-button
+    >
+      Update
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/application-resource/application-options/application-options.component.scss
+++ b/src/app/dashboard/auth/application-resource/application-options/application-options.component.scss
@@ -1,0 +1,44 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}
+
+.select-role {
+  display: grid;
+  grid-template-columns: auto 0.15fr;
+  gap: 0.5rem;
+  button {
+    height: 59.5px;
+  }
+  margin-bottom: 1rem;
+}
+
+.roles-list {
+  display: grid;
+  grid-template-columns: auto 0.1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  .role-title {
+    border-radius: 0.25rem;
+    background-color: rgba(130, 199, 255, 0.267);
+    h3 {
+      margin: 0;
+    }
+    padding: 1rem;
+  }
+}
+
+.options-list-container {
+  max-height: 400px;
+}

--- a/src/app/dashboard/auth/application-resource/application-options/application-options.component.spec.ts
+++ b/src/app/dashboard/auth/application-resource/application-options/application-options.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ApplicationOptionsComponent } from './application-options.component';
+
+describe('ApplicationOptionsComponent', () => {
+  let component: ApplicationOptionsComponent;
+  let fixture: ComponentFixture<ApplicationOptionsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ApplicationOptionsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ApplicationOptionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/application-resource/application-options/application-options.component.ts
+++ b/src/app/dashboard/auth/application-resource/application-options/application-options.component.ts
@@ -1,0 +1,100 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Option, Resource, ResourceService } from 'src/app/dashboard/services/resource.service';
+
+@Component({
+  selector: 'application-options',
+  templateUrl: './application-options.component.html',
+  styleUrls: ['./application-options.component.scss'],
+})
+export class ApplicationOptionsComponent implements OnInit {
+  addResourceOptionForm: FormGroup;
+  errorMessage!: string;
+  errorMessageRoles!: string;
+  options: Option[] = [];
+  optionsList: Option[] = [];
+  hidePassword = true;
+
+  constructor(
+    public dialogRef: MatDialogRef<ApplicationOptionsComponent>,
+    private formBuilder: FormBuilder,
+    private resourceService: ResourceService,
+    @Inject(MAT_DIALOG_DATA) public resource: Resource
+  ) {
+    this.optionsList = [...resource.allowed];
+    this.addResourceOptionForm = this.formBuilder.group({
+      name: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/\s]+$/),
+          Validators.minLength(1),
+          Validators.maxLength(40),
+        ])
+      ),
+    });
+  }
+
+  ngOnInit(): void {}
+
+  isBasicOption(allowed: string) {
+    const basicOptions = ['*', 'create', 'select', 'update', 'delete'];
+    const indexOfAllowed = basicOptions.indexOf(allowed);
+    if (indexOfAllowed === -1) return false;
+    return true;
+  }
+
+  addOptionToList() {
+    const currentNameValue =
+      (this.addResourceOptionForm.get('name')?.value as string) || '';
+    if (currentNameValue === '') return;
+    const indexOfCurrent = this.optionsList.findIndex(
+      (option) =>
+        option.allowed.toLowerCase() === currentNameValue.toLowerCase()
+    );
+    if (
+      indexOfCurrent === -1 &&
+      this.addResourceOptionForm.get('name')?.valid
+    ) {
+      this.optionsList.push({
+        id: 0,
+        allowed: this.addResourceOptionForm.get('name')?.value,
+      });
+      this.addResourceOptionForm.get('name')?.reset();
+    }
+  }
+
+  removeFromOptionList(optionToRemove: Option) {
+    const indexToRemove = this.optionsList.findIndex(
+      (option) =>
+        option.allowed.toLowerCase() === optionToRemove.allowed.toLowerCase()
+    );
+    this.optionsList.splice(indexToRemove, 1);
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  updateResourceOptions() {
+    this.resourceService
+      .updateResourceOptions(
+        this.resource.id,
+        this.optionsList,
+        this.resource.allowed
+      )
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/application-resource/application-resource.component.html
+++ b/src/app/dashboard/auth/application-resource/application-resource.component.html
@@ -1,0 +1,83 @@
+<div class="role-container">
+  <div class="role-head">
+    <h1 class="role-title">Applications Resources</h1>
+    <span class="separator"></span>
+    <button
+      (click)="openCreateAppResourceDialog()"
+      color="accent"
+      mat-flat-button
+    >
+      Add Resource
+    </button>
+  </div>
+  <div class="role-body">
+    <div class="container-table mat-elevation-z8">
+      <div class="loading-shade" *ngIf="isLoadingResults">
+        <mat-spinner *ngIf="isLoadingResults"></mat-spinner>
+      </div>
+      <div class="example-table-container">
+        <table
+          mat-table
+          [dataSource]="resources"
+          class="user-table"
+          matSort
+          matSortActive="id"
+          matSortDisableClear
+          matSortDirection="asc"
+        >
+          <ng-container matColumnDef="id">
+            <th mat-sort-header mat-header-cell *matHeaderCellDef>id</th>
+            <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="applicationResourceName">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let row">
+              {{ row.applicationResourceName }}
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="options">
+            <th mat-header-cell *matHeaderCellDef>Resource Options</th>
+            <td class="roles-column" mat-cell *matCellDef="let row">
+              <button
+                [disabled]="
+                  masterResources.indexOf(row.applicationResourceName) !== -1
+                "
+                (click)="openOptionsDialog(row)"
+                mat-stroked-button
+              >
+                Options
+              </button>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="delete">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td class="actions-column" mat-cell *matCellDef="let row">
+              <button
+                color="warn"
+                [disabled]="
+                  masterResources.indexOf(row.applicationResourceName) !== -1
+                "
+                mat-stroked-button
+                (click)="openDeleteResourceDialog(row)"
+              >
+                Delete Resource
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        </table>
+      </div>
+
+      <mat-paginator
+        [length]="resultsLength"
+        [pageSize]="20"
+        aria-label="Select page of GitHub search results"
+      ></mat-paginator>
+    </div>
+  </div>
+</div>

--- a/src/app/dashboard/auth/application-resource/application-resource.component.scss
+++ b/src/app/dashboard/auth/application-resource/application-resource.component.scss
@@ -1,0 +1,52 @@
+.role-container {
+  .role-head {
+    .separator {
+      flex: 1 0;
+    }
+
+    .role-title {
+      margin: 0;
+      font-size: 32px;
+    }
+
+    display: flex;
+
+    margin-bottom: 2rem;
+  }
+
+  table {
+    width: 100%;
+    th,
+    td {
+      width: 20%;
+    }
+    .roles-column {
+      button:last-child {
+        margin-left: 0.5rem;
+      }
+    }
+    .actions-column {
+      text-align: end;
+      button:last-child {
+        margin-left: 0.5rem;
+      }
+    }
+  }
+
+  .container-table {
+    position: relative;
+  }
+
+  .loading-shade {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 56px;
+    right: 0;
+    background: rgba(0, 0, 0, 0.15);
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/src/app/dashboard/auth/application-resource/application-resource.component.spec.ts
+++ b/src/app/dashboard/auth/application-resource/application-resource.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ApplicationResourceComponent } from './application-resource.component';
+
+describe('ApplicationResourceComponent', () => {
+  let component: ApplicationResourceComponent;
+  let fixture: ComponentFixture<ApplicationResourceComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ApplicationResourceComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ApplicationResourceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/application-resource/application-resource.component.ts
+++ b/src/app/dashboard/auth/application-resource/application-resource.component.ts
@@ -1,0 +1,179 @@
+import {
+  AfterViewInit,
+  Component,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import {
+  BehaviorSubject,
+  Subscription,
+  merge,
+  startWith,
+  switchMap,
+  catchError,
+  of,
+  map,
+  first,
+} from 'rxjs';
+import { ApplicationOptionsComponent } from './application-options/application-options.component';
+import { CreateApplicationResourceComponent } from './create-application-resource/create-application-resource.component';
+import { DeleteApplicationResourceComponent } from './delete-application-resource/delete-application-resource.component';
+import { Resource, ResourceService } from '../../services/resource.service';
+
+@Component({
+  selector: 'application-resource',
+  templateUrl: './application-resource.component.html',
+  styleUrls: ['./application-resource.component.scss'],
+})
+export class ApplicationResourceComponent
+  implements OnInit, OnDestroy, AfterViewInit
+{
+  resources!: Resource[];
+  errorMessage!: string | undefined;
+  displayedColumns: string[] = [
+    'id',
+    'applicationResourceName',
+    'options',
+    'delete',
+  ];
+
+  masterResources = [
+    'OAUTH2_global',
+    'OAUTH2_user',
+    'OAUTH2_client',
+    'OAUTH2_application',
+    'OAUTH2_role',
+    'OAUTH2_option',
+  ];
+
+  resultsLength = 0;
+  isLoadingResults = true;
+
+  reload = new BehaviorSubject<number>(0);
+
+  userDataSubscription!: Subscription;
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(
+    private resourceServie: ResourceService,
+    public dialog: MatDialog
+  ) {}
+
+  ngOnDestroy(): void {
+    this.userDataSubscription?.unsubscribe();
+    this.sort.sortChange.complete();
+  }
+
+  ngAfterViewInit(): void {
+    this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
+    this.userDataSubscription = merge(
+      this.sort.sortChange,
+      this.paginator.page,
+      this.reload
+    )
+      .pipe(
+        startWith({}),
+        switchMap(() => {
+          this.errorMessage = undefined;
+          this.isLoadingResults = true;
+          return this.resourceServie!.getResources(
+            this.paginator.pageIndex,
+            this.sort.direction
+          ).pipe(
+            catchError((err) => {
+              if (err.error) {
+                this.errorMessage = err.error.message;
+              } else {
+                this.errorMessage = 'Unknown Error';
+              }
+              return of(null);
+            })
+          );
+        }),
+        map((data) => {
+          this.isLoadingResults = false;
+          if (data === null) {
+            return [];
+          }
+          this.resultsLength = data.content?.totalItems || 0;
+          return data.content?.items || [];
+        })
+      )
+      .subscribe((data) => {
+        this.resources = data;
+      });
+  }
+
+  ngOnInit(): void {}
+
+  openCreateAppResourceDialog() {
+    const createResourceOptionsDialogRef = this.dialog.open(
+      CreateApplicationResourceComponent,
+      {
+        width: '600px',
+        maxHeight: '70vh',
+      }
+    );
+
+    createResourceOptionsDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+
+  openDeleteResourceDialog(resource: Resource) {
+    const deleteResourceOptionsDialogRef = this.dialog.open(
+      DeleteApplicationResourceComponent,
+      {
+        width: '600px',
+        maxHeight: '70vh',
+        data: resource,
+      }
+    );
+
+    deleteResourceOptionsDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+
+  openOptionsDialog(resource: Resource) {
+    const updateResourceOptionsDialogRef = this.dialog.open(
+      ApplicationOptionsComponent,
+      {
+        width: '600px',
+        maxHeight: '70vh',
+        data: resource,
+      }
+    );
+
+    updateResourceOptionsDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.html
+++ b/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.html
@@ -1,0 +1,49 @@
+<h2 mat-dialog-title>Create Application Resource</h2>
+<form
+  [formGroup]="createResourceForm"
+  (ngSubmit)="createResource(createResourceForm.value)"
+>
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Identifier</mat-label>
+      <input
+        matInput
+        formControlName="resourceIdentifier"
+        name="resourceIdentifier"
+        required
+      />
+      <mat-hint>The resource name</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Select A Application</mat-label>
+      <mat-select name="application" formControlName="application">
+        <mat-option
+          [value]="application.id"
+          *ngFor="let application of applications"
+          >{{ application.identifier }}</mat-option
+        >
+      </mat-select>
+      <mat-hint>Select an application</mat-hint>
+    </mat-form-field>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!createResourceForm.valid || loadingResult"
+      color="primary"
+      mat-flat-button
+    >
+      Create
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.scss
+++ b/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.scss
@@ -1,0 +1,4 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.spec.ts
+++ b/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateApplicationResourceComponent } from './create-application-resource.component';
+
+describe('CreateApplicationResourceComponent', () => {
+  let component: CreateApplicationResourceComponent;
+  let fixture: ComponentFixture<CreateApplicationResourceComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CreateApplicationResourceComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateApplicationResourceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.ts
+++ b/src/app/dashboard/auth/application-resource/create-application-resource/create-application-resource.component.ts
@@ -1,0 +1,90 @@
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { Application, ApplicationService } from 'src/app/dashboard/services/application.service';
+import { ResourceService } from 'src/app/dashboard/services/resource.service';
+
+@Component({
+  selector: 'lib-create-application-resource',
+  templateUrl: './create-application-resource.component.html',
+  styleUrls: ['./create-application-resource.component.scss'],
+})
+export class CreateApplicationResourceComponent implements OnInit {
+  createResourceForm: FormGroup;
+  errorMessage!: string;
+  errorMessageRoles!: string;
+  applications: Application[] = [];
+  hidePassword = true;
+
+  loadingResult = false;
+
+  constructor(
+    public dialogRef: MatDialogRef<CreateApplicationResourceComponent>,
+    private formBuilder: FormBuilder,
+    private resourceService: ResourceService,
+    private applicationService: ApplicationService
+  ) {
+    this.applicationService.getApplications().subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+        this.applications = [];
+      },
+      next: (res) => {
+        this.applications = res.content || [];
+      },
+    });
+    this.createResourceForm = this.formBuilder.group({
+      resourceIdentifier: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.minLength(4),
+          Validators.maxLength(45),
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/]+$/),
+        ])
+      ),
+      application: this.formBuilder.control(
+        '',
+        Validators.compose([Validators.required, Validators.min(1)])
+      ),
+    });
+  }
+
+  ngOnInit(): void {}
+
+  createResource(createResourceForm: {
+    resourceIdentifier: string;
+    application: number;
+  }) {
+    this.loadingResult = true;
+    this.resourceService
+      .createResource(
+        createResourceForm.resourceIdentifier,
+        createResourceForm.application
+      )
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+        complete: () => {
+          this.loadingResult = false;
+        },
+      });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/application-resource/delete-application-resource/delete-application-resource.component.html
+++ b/src/app/dashboard/auth/application-resource/delete-application-resource/delete-application-resource.component.html
@@ -1,0 +1,26 @@
+<h2 mat-dialog-title>Delete Resource {{ resource.applicationResourceName }}</h2>
+<div mat-dialog-content>
+  <div class="error-display" *ngIf="errorMessage">
+    <h5>{{ errorMessage }}</h5>
+  </div>
+  <p>Are you sure?</p>
+</div>
+<div align="end" mat-dialog-actions>
+  <button
+    (click)="closeDialog()"
+    type="button"
+    color="warn"
+    mat-stroked-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Cancel</button
+  ><button
+    (click)="delete()"
+    type="button"
+    color="primary"
+    mat-flat-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Delete
+  </button>
+</div>

--- a/src/app/dashboard/auth/application-resource/delete-application-resource/delete-application-resource.component.spec.ts
+++ b/src/app/dashboard/auth/application-resource/delete-application-resource/delete-application-resource.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteApplicationResourceComponent } from './delete-application-resource.component';
+
+describe('DeleteApplicationResourceComponent', () => {
+  let component: DeleteApplicationResourceComponent;
+  let fixture: ComponentFixture<DeleteApplicationResourceComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DeleteApplicationResourceComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteApplicationResourceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/application-resource/delete-application-resource/delete-application-resource.component.ts
+++ b/src/app/dashboard/auth/application-resource/delete-application-resource/delete-application-resource.component.ts
@@ -1,0 +1,46 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Resource, ResourceService } from 'src/app/dashboard/services/resource.service';
+
+@Component({
+  selector: 'delete-application-resource',
+  templateUrl: './delete-application-resource.component.html',
+  styleUrls: ['./delete-application-resource.component.scss'],
+})
+export class DeleteApplicationResourceComponent implements OnInit {
+  errorMessage!: string;
+  loadingResult = false;
+
+  constructor(
+    public dialogRef: MatDialogRef<DeleteApplicationResourceComponent>,
+    private resourceService: ResourceService, 
+    @Inject(MAT_DIALOG_DATA) public resource: Resource
+  ) {}
+
+  ngOnInit(): void {}
+
+  delete() {
+    this.loadingResult = true;
+    this.dialogRef.disableClose = true;
+    this.resourceService.deleteResource(this.resource.id).subscribe({
+      error: (err) => {
+        this.dialogRef.disableClose = false;
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.dialogRef.close(true);
+      },
+      complete: () => {
+        this.loadingResult = false;
+      },
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.html
+++ b/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.html
@@ -1,0 +1,52 @@
+<h2 mat-dialog-title>Modify roles of {{ client.name }}</h2>
+<form [formGroup]="addRolesForm" (ngSubmit)="updateRoles()">
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <div class="select-role">
+      <mat-form-field class="forms-field" appearance="fill">
+        <mat-label>Select A Role</mat-label>
+        <mat-select name="role" formControlName="role">
+          <mat-option [value]="role" *ngFor="let role of roles">{{
+            role.identifier
+          }}</mat-option>
+        </mat-select>
+        <mat-hint>Select a role and add it</mat-hint>
+      </mat-form-field>
+      <button type="button" (click)="addRoleToList()" mat-stroked-button>
+        +
+      </button>
+    </div>
+    <div *ngFor="let role of rolesList" class="roles-list">
+      <div class="role-title">
+        <h3>{{ role.identifier }}</h3>
+      </div>
+      <button
+        (click)="removeRoleToList(role)"
+        color="warn"
+        type="button"
+        mat-stroked-button
+      >
+        -
+      </button>
+    </div>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!addRolesForm.valid || rolesList.length === 0"
+      color="primary"
+      mat-flat-button
+    >
+      Update
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.scss
+++ b/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.scss
@@ -1,0 +1,40 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}
+
+.select-role {
+  display: grid;
+  grid-template-columns: auto 0.15fr;
+  gap: 0.5rem;
+  button {
+    height: 59.5px;
+  }
+  margin-bottom: 1rem;
+}
+
+.roles-list {
+  display: grid;
+  grid-template-columns: auto 0.1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  .role-title {
+    border-radius: 0.25rem;
+    background-color: rgba(130, 199, 255, 0.267);
+    h3 {
+      margin: 0;
+    }
+    padding: 1rem;
+  }
+}

--- a/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.spec.ts
+++ b/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddClientRolesComponent } from './add-client-roles.component';
+
+describe('AddClientRolesComponent', () => {
+  let component: AddClientRolesComponent;
+  let fixture: ComponentFixture<AddClientRolesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AddClientRolesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddClientRolesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.ts
+++ b/src/app/dashboard/auth/client/add-client-roles/add-client-roles.component.ts
@@ -1,0 +1,101 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Client, ClientService } from 'src/app/dashboard/services/client.service';
+import { BasicRole, RoleService } from 'src/app/dashboard/services/role.service';
+
+@Component({
+  selector: 'add-client-roles',
+  templateUrl: './add-client-roles.component.html',
+  styleUrls: ['./add-client-roles.component.scss'],
+})
+export class AddClientRolesComponent implements OnInit {
+  addRolesForm: FormGroup;
+  errorMessage!: string;
+  errorMessageRoles!: string;
+  roles: BasicRole[] = [];
+  rolesList: BasicRole[] = [];
+
+  constructor(
+    public dialogRef: MatDialogRef<AddClientRolesComponent>,
+    private formBuilder: FormBuilder,
+    private clientService: ClientService,
+    private roleService: RoleService,
+    @Inject(MAT_DIALOG_DATA) public client: Client
+  ) {
+    this.roleService.getRolesBasic().subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+        this.roles = [];
+      },
+      next: (res) => {
+        const availableRoles = res.content?.flatMap((c) => {
+          const roleExist = client.roles.findIndex(
+            (r) => c.id == r.id
+          ) as number;
+          if (roleExist === -1) {
+            return c;
+          }
+          this.rolesList.push(c);
+          return [];
+        });
+        this.roles = availableRoles || [];
+      },
+    });
+    this.addRolesForm = this.formBuilder.group({
+      role: this.formBuilder.control(''),
+    });
+  }
+
+  ngOnInit(): void {}
+  addRoleToList() {
+    const roleValue = this.addRolesForm.get('role')?.value;
+    if (!roleValue) {
+      return;
+    }
+    const indexOfRole = this.roles.indexOf(roleValue);
+    this.roles.splice(indexOfRole, 1);
+    this.rolesList.push(roleValue);
+    this.addRolesForm.get('role')?.setValue('');
+  }
+
+  removeRoleToList(role: BasicRole) {
+    const roleValue = role;
+    const indexOfRole = this.rolesList.findIndex((r) => r.id == roleValue.id);
+    this.roles.unshift(role);
+    this.rolesList.splice(indexOfRole, 1);
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  updateRoles() {
+    const basicOriginalRoles = this.client.roles.map((rl) => {
+      return { id: rl.id, identifier: rl.identifier };
+    });
+    this.clientService
+      .updateClientRoles(
+        this.client.subjectId,
+        this.rolesList,
+        basicOriginalRoles
+      )
+      .subscribe({
+        error: (err) => {
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+          this.roles = [];
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/client/client.component.html
+++ b/src/app/dashboard/auth/client/client.component.html
@@ -1,0 +1,137 @@
+<div class="client-container">
+  <div class="client-head">
+    <h1 class="client-title">Clients</h1>
+    <span class="separator"></span>
+    <button (click)="openCreateClientDialog()" color="accent" mat-flat-button>
+      Add Client
+    </button>
+  </div>
+  <div class="client-body">
+    <div class="container-table mat-elevation-z8">
+      <div class="loading-shade" *ngIf="isLoadingResults">
+        <mat-spinner *ngIf="isLoadingResults"></mat-spinner>
+      </div>
+
+      <div class="example-table-container">
+        <table
+          mat-table
+          [dataSource]="clients"
+          class="client-table"
+          matSort
+          matSortActive="id"
+          matSortDisableClear
+          matSortDirection="asc"
+        >
+          <ng-container matColumnDef="id">
+            <th mat-sort-header mat-header-cell *matHeaderCellDef>id</th>
+            <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="name">
+            <th mat-header-cell *matHeaderCellDef>Name</th>
+            <td mat-cell *matCellDef="let row">{{ row.name }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="identifier">
+            <th mat-header-cell *matHeaderCellDef>Identifier</th>
+            <td mat-cell *matCellDef="let row">{{ row.identifier }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="clientSecret">
+            <th mat-header-cell *matHeaderCellDef>Secret</th>
+            <td class="roles-column" mat-cell *matCellDef="let row">
+              <button (click)="openShowSecretComponent(row)" mat-stroked-button>
+                Secret Key
+              </button>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="accessToken">
+            <th mat-header-cell *matHeaderCellDef>Access Token</th>
+            <td class="roles-column" mat-cell *matCellDef="let row">
+              <button
+                (click)="generateNewLongLiveToken(row)"
+                mat-stroked-button
+                *ngIf="!row.hasLongLiveToken"
+              >
+                Generate Long Live
+              </button>
+              <button
+                *ngIf="row.hasLongLiveToken"
+                color="warn"
+                (click)="removeLongLiveToken(row)"
+                mat-stroked-button
+              >
+                Remove Long Live
+              </button>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="roles">
+            <th mat-header-cell *matHeaderCellDef>Roles</th>
+            <td class="roles-column" mat-cell *matCellDef="let row">
+              <button (click)="openViewRolesDialog(row)" mat-stroked-button>
+                View Roles
+              </button>
+              <button
+                [disabled]="row.identifier === 'admin'"
+                (click)="openUpdateRolesDialog(row)"
+                mat-stroked-button
+              >
+                Update Roles
+              </button>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="edit">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td class="actions-column" mat-cell *matCellDef="let row">
+              <button
+                *ngIf="!row.revoked"
+                color="primary"
+                [disabled]="row.identifier === 'admin'"
+                mat-stroked-button
+                (click)="revokeClient(row)"
+              >
+                Revoke Client
+              </button>
+              <button
+                *ngIf="row.revoked"
+                color="primary"
+                [disabled]="row.identifier === 'admin'"
+                mat-stroked-button
+                (click)="ratifyClient(row)"
+              >
+                Ratify Client
+              </button>
+              <button
+                color="primary"
+                [disabled]="row.identifier === 'admin'"
+                mat-stroked-button
+                (click)="openUpdateClientDialog(row)"
+              >
+                Edit Client
+              </button>
+              <button
+                color="warn"
+                [disabled]="row.identifier === 'admin'"
+                mat-stroked-button
+                (click)="openDialogDeleteClient(row)"
+              >
+                Delete Client
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        </table>
+      </div>
+
+      <mat-paginator [length]="resultsLength" [pageSize]="20"></mat-paginator>
+    </div>
+  </div>
+</div>
+<div *ngIf="wholePageLoading" class="loading-full">
+  <mat-spinner></mat-spinner>
+</div>

--- a/src/app/dashboard/auth/client/client.component.scss
+++ b/src/app/dashboard/auth/client/client.component.scss
@@ -1,0 +1,68 @@
+.client-container {
+  .client-head {
+    .separator {
+      flex: 1 0;
+    }
+
+    .client-title {
+      margin: 0;
+      font-size: 32px;
+    }
+
+    display: flex;
+
+    margin-bottom: 2rem;
+  }
+
+  table {
+    width: 100%;
+    overflow-x: auto;
+    th,
+    td {
+      min-width: 80px;
+    }
+    .roles-column {
+      button:last-child {
+        margin-left: 0.5rem;
+      }
+    }
+    .actions-column {
+      text-align: end;
+      button {
+        margin-left: 0.5rem;
+      }
+    }
+  }
+
+  .container-table {
+    position: relative;
+  }
+
+  .loading-shade {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 56px;
+    right: 0;
+    background: rgba(0, 0, 0, 0.15);
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.loading-full {
+  pointer-events: all;
+  z-index: 99999;
+  border: none;
+  margin: 0px;
+  padding: 0px;
+  width: 100%;
+  height: 100%;
+  top: 0px;
+  left: 0px;
+  cursor: wait;
+  position: fixed;
+  background-color: rgba(0, 0, 0, 0.6);
+}

--- a/src/app/dashboard/auth/client/client.component.spec.ts
+++ b/src/app/dashboard/auth/client/client.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClientComponent } from './client.component';
+
+describe('ClientComponent', () => {
+  let component: ClientComponent;
+  let fixture: ComponentFixture<ClientComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ClientComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ClientComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/client.component.ts
+++ b/src/app/dashboard/auth/client/client.component.ts
@@ -1,0 +1,280 @@
+import { ShowSecretComponent } from './show-secret/show-secret.component';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import {
+  BehaviorSubject,
+  Subscription,
+  merge,
+  startWith,
+  switchMap,
+  catchError,
+  of,
+  map,
+  first,
+} from 'rxjs';
+import { AddClientRolesComponent } from './add-client-roles/add-client-roles.component';
+import { CreateClientComponent } from './create-client/create-client.component';
+import { DeleteClientComponent } from './delete-client/delete-client.component';
+import { ShowTokenComponent } from './show-token/show-token.component';
+import { UpdateClientComponent } from './update-client/update-client.component';
+import { ViewClientRolesComponent } from './view-client-roles/view-client-roles.component';
+import { ShowNewTokenComponent } from './show-new-token/show-new-token.component';
+import { Client, ClientCreateContent, ClientService } from '../../services/client.service';
+
+@Component({
+  selector: 'client',
+  templateUrl: './client.component.html',
+  styleUrls: ['./client.component.scss'],
+})
+export class ClientComponent implements OnInit {
+  clients!: Client[];
+  errorMessage!: string | undefined;
+  displayedColumns: string[] = [
+    'id',
+    'name',
+    'identifier',
+    'clientSecret',
+    'accessToken',
+    'roles',
+    'edit',
+  ];
+
+  resultsLength = 0;
+  isLoadingResults = true;
+  wholePageLoading = false;
+
+  reload = new BehaviorSubject<number>(0);
+
+  clientDataSubscription!: Subscription;
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(
+    private clientService: ClientService,
+    public dialog: MatDialog
+  ) {}
+
+  ngAfterViewInit(): void {
+    this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
+    this.clientDataSubscription = merge(
+      this.sort.sortChange,
+      this.paginator.page,
+      this.reload
+    )
+      .pipe(
+        startWith({}),
+        switchMap(() => {
+          this.errorMessage = undefined;
+          this.isLoadingResults = true;
+          return this.clientService!.getClients(
+            this.paginator.pageIndex,
+            this.sort.direction
+          ).pipe(
+            catchError((err) => {
+              if (err.error) {
+                this.errorMessage = err.error.message;
+              } else {
+                this.errorMessage = 'Unknown Error';
+              }
+              return of(null);
+            })
+          );
+        }),
+        map((data) => {
+          this.isLoadingResults = false;
+          if (data === null) {
+            return [];
+          }
+          this.resultsLength = data.content?.totalItems || 0;
+          return data.content?.items || [];
+        })
+      )
+      .subscribe((data) => {
+        this.clients = data;
+      });
+  }
+
+  ngOnInit(): void {}
+
+  ngOnDestroy(): void {
+    this.clientDataSubscription?.unsubscribe();
+    this.sort.sortChange.complete();
+  }
+
+  openShowSecretComponent(client: Client) {
+    this.dialog.open(ShowSecretComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: client,
+    });
+  }
+
+  generateNewLongLiveToken(client: Client) {
+    this.clientService
+      .generateLongLiveToken(client.id, client.identifier)
+      .subscribe({
+        error: (err) => {
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: (res) => {
+          this.reload.next(this.reload.value + 1);
+          this.dialog.open(ShowNewTokenComponent, {
+            width: '600px',
+            maxHeight: '70vh',
+            data: { access_token: res.content.access_token },
+          });
+        },
+      });
+  }
+
+  removeLongLiveToken(client: Client) {
+    this.wholePageLoading = true;
+    this.clientService.removeLongLiveToken(client.id, client.identifier).subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.reload.next(this.reload.value + 1);
+      },
+      complete: () => {
+        this.wholePageLoading = false;
+      },
+    });
+  }
+
+  revokeClient(client: Client) {
+    this.wholePageLoading = true;
+    this.clientService.modifyRevokeStatus(client.id, true).subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.reload.next(this.reload.value + 1);
+      },
+      complete: () => {
+        this.wholePageLoading = false;
+      },
+    });
+  }
+
+  ratifyClient(client: Client) {
+    this.wholePageLoading = true;
+    this.clientService.modifyRevokeStatus(client.id, false).subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.reload.next(this.reload.value + 1);
+      },
+      complete: () => {
+        this.wholePageLoading = false;
+      },
+    });
+  }
+
+  openCreateClientDialog() {
+    const createClientDialogRef = this.dialog.open(CreateClientComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+    });
+    createClientDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res: ClientCreateContent) => {
+          if (res) {
+            this.dialog.open(ShowTokenComponent, {
+              width: '600px',
+              maxHeight: '70vh',
+              data: res,
+            });
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+
+  openViewRolesDialog(client: Client) {
+    this.dialog.open(ViewClientRolesComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: client,
+    });
+  }
+
+  openUpdateRolesDialog(client: Client) {
+    const updateRolesDialogRef = this.dialog.open(AddClientRolesComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: client,
+    });
+
+    updateRolesDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+
+  openUpdateClientDialog(client: Client) {
+    const updateClientDialogRef = this.dialog.open(UpdateClientComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: client,
+    });
+
+    updateClientDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+
+  openDialogDeleteClient(client: Client) {
+    const updateRolesDialogRef = this.dialog.open(DeleteClientComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: client,
+    });
+
+    updateRolesDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/client/create-client/create-client.component.html
+++ b/src/app/dashboard/auth/client/create-client/create-client.component.html
@@ -1,0 +1,87 @@
+<h2 mat-dialog-title>Create Client</h2>
+<form
+  [formGroup]="createClientForm"
+  (ngSubmit)="createClient(createClientForm.value)"
+>
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" name="name" required />
+      <mat-hint>Put the client name</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Description</mat-label>
+      <textarea
+        matInput
+        formControlName="description"
+        name="description"
+        required
+      ></textarea>
+      <mat-hint>Breve user description</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Identifier</mat-label>
+      <input
+        matInput
+        placeholder="admin01"
+        formControlName="identifier"
+        name="identifier"
+        required
+      />
+      <mat-hint>Client unique identifier</mat-hint>
+    </mat-form-field>
+    <div class="select-role">
+      <mat-form-field class="forms-field" appearance="fill">
+        <mat-label>Select A Role</mat-label>
+        <mat-select name="role" formControlName="role">
+          <mat-option [value]="role" *ngFor="let role of roles">{{
+            role.identifier
+          }}</mat-option>
+        </mat-select>
+        <mat-hint>Select a role and add it</mat-hint>
+      </mat-form-field>
+      <button type="button" (click)="addRoleToList()" mat-stroked-button>
+        +
+      </button>
+    </div>
+    <div *ngFor="let role of rolesList" class="roles-list">
+      <div class="role-title">
+        <h3>{{ role.identifier }}</h3>
+      </div>
+      <button
+        (click)="removeRoleToList(role)"
+        color="warn"
+        type="button"
+        mat-stroked-button
+      >
+        -
+      </button>
+    </div>
+    <div class="check-container">
+      <h4>Create with a long live token:</h4>
+      <p>
+        <mat-checkbox formControlName="longLive">Long Live Token</mat-checkbox>
+      </p>
+    </div>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!createClientForm.valid || rolesList.length === 0"
+      color="primary"
+      mat-flat-button
+    >
+      Create
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/client/create-client/create-client.component.scss
+++ b/src/app/dashboard/auth/client/create-client/create-client.component.scss
@@ -1,0 +1,40 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}
+
+.select-role {
+  display: grid;
+  grid-template-columns: auto 0.15fr;
+  gap: 0.5rem;
+  button {
+    height: 59.5px;
+  }
+  margin-bottom: 1rem;
+}
+
+.roles-list {
+  display: grid;
+  grid-template-columns: auto 0.1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  .role-title {
+    border-radius: 0.25rem;
+    background-color: rgba(130, 199, 255, 0.267);
+    h3 {
+      margin: 0;
+    }
+    padding: 1rem;
+  }
+}

--- a/src/app/dashboard/auth/client/create-client/create-client.component.spec.ts
+++ b/src/app/dashboard/auth/client/create-client/create-client.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateClientComponent } from './create-client.component';
+
+describe('CreateClientComponent', () => {
+  let component: CreateClientComponent;
+  let fixture: ComponentFixture<CreateClientComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CreateClientComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateClientComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/create-client/create-client.component.ts
+++ b/src/app/dashboard/auth/client/create-client/create-client.component.ts
@@ -1,0 +1,121 @@
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { ClientService } from 'src/app/dashboard/services/client.service';
+import { BasicRole, RoleService } from 'src/app/dashboard/services/role.service';
+
+@Component({
+  selector: 'create-client',
+  templateUrl: './create-client.component.html',
+  styleUrls: ['./create-client.component.scss'],
+})
+export class CreateClientComponent implements OnInit {
+  createClientForm: FormGroup;
+  errorMessage!: string;
+  errorMessageRoles!: string;
+  roles: BasicRole[] = [];
+  rolesList: BasicRole[] = [];
+  hidePassword = true;
+
+  constructor(
+    public dialogRef: MatDialogRef<CreateClientComponent>,
+    private formBuilder: FormBuilder,
+    private clientService: ClientService,
+    private roleService: RoleService
+  ) {
+    this.roleService.getRolesBasic().subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+        this.roles = [];
+      },
+      next: (res) => {
+        this.roles = res.content || [];
+      },
+    });
+    this.createClientForm = this.formBuilder.group({
+      name: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.minLength(4),
+          Validators.maxLength(45),
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/\s]+$/),
+        ])
+      ),
+      description: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.minLength(4),
+          Validators.maxLength(255),
+        ])
+      ),
+      identifier: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/]+$/),
+          Validators.minLength(4),
+          Validators.maxLength(20),
+        ])
+      ),
+      role: this.formBuilder.control(''),
+      longLive: this.formBuilder.control(false),
+    });
+  }
+
+  ngOnInit(): void {}
+
+  addRoleToList() {
+    const roleValue = this.createClientForm.get('role')?.value;
+    if (!roleValue) {
+      return;
+    }
+    const indexOfRole = this.roles.indexOf(roleValue);
+    this.roles.splice(indexOfRole, 1);
+    this.rolesList.push(roleValue);
+    this.createClientForm.get('role')?.setValue('');
+  }
+
+  removeRoleToList(role: BasicRole) {
+    const roleValue = role;
+    const indexOfRole = this.rolesList.indexOf(roleValue);
+    this.roles.unshift(role);
+    this.rolesList.splice(indexOfRole, 1);
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  createClient(createClientData: {
+    name: string;
+    identifier: string;
+    role: string | undefined;
+    longLive?: boolean;
+  }) {
+    const longLive = createClientData.longLive || false;
+    createClientData.role = undefined;
+    createClientData.longLive = undefined;
+    this.dialogRef.disableClose = true;
+    this.clientService
+      .createClient({ ...createClientData, roles: this.rolesList }, longLive)
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: (res) => {
+          this.dialogRef.close(res.content);
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/client/delete-client/delete-client.component.html
+++ b/src/app/dashboard/auth/client/delete-client/delete-client.component.html
@@ -1,0 +1,26 @@
+<h2 mat-dialog-title>Delete Client {{ client.name }}</h2>
+<div mat-dialog-content>
+  <div class="error-display" *ngIf="errorMessage">
+    <h5>{{ errorMessage }}</h5>
+  </div>
+  <p>Are you sure?</p>
+</div>
+<div align="end" mat-dialog-actions>
+  <button
+    (click)="closeDialog()"
+    type="button"
+    color="warn"
+    mat-stroked-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Cancel</button
+  ><button
+    (click)="delete()"
+    type="button"
+    color="primary"
+    mat-flat-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Delete
+  </button>
+</div>

--- a/src/app/dashboard/auth/client/delete-client/delete-client.component.spec.ts
+++ b/src/app/dashboard/auth/client/delete-client/delete-client.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteClientComponent } from './delete-client.component';
+
+describe('DeleteClientComponent', () => {
+  let component: DeleteClientComponent;
+  let fixture: ComponentFixture<DeleteClientComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeleteClientComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteClientComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/delete-client/delete-client.component.ts
+++ b/src/app/dashboard/auth/client/delete-client/delete-client.component.ts
@@ -1,0 +1,41 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Client, ClientService } from 'src/app/dashboard/services/client.service';
+
+@Component({
+  selector: 'delete-client',
+  templateUrl: './delete-client.component.html',
+  styleUrls: ['./delete-client.component.scss'],
+})
+export class DeleteClientComponent implements OnInit {
+  errorMessage!: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<DeleteClientComponent>,
+    private clientService: ClientService,
+    @Inject(MAT_DIALOG_DATA) public client: Client
+  ) {}
+
+  ngOnInit(): void {}
+
+  delete() {
+    this.dialogRef.disableClose = true;
+    this.clientService.deleteClient(this.client.subjectId).subscribe({
+      error: (err) => {
+        this.dialogRef.disableClose = false;
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.dialogRef.close(true);
+      },
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/client/revoke-token/revoke-token.component.html
+++ b/src/app/dashboard/auth/client/revoke-token/revoke-token.component.html
@@ -1,0 +1,1 @@
+<p>revoke-token works!</p>

--- a/src/app/dashboard/auth/client/revoke-token/revoke-token.component.spec.ts
+++ b/src/app/dashboard/auth/client/revoke-token/revoke-token.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RevokeTokenComponent } from './revoke-token.component';
+
+describe('RevokeTokenComponent', () => {
+  let component: RevokeTokenComponent;
+  let fixture: ComponentFixture<RevokeTokenComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RevokeTokenComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RevokeTokenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/revoke-token/revoke-token.component.ts
+++ b/src/app/dashboard/auth/client/revoke-token/revoke-token.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'revoke-token',
+  templateUrl: './revoke-token.component.html',
+  styleUrls: ['./revoke-token.component.css']
+})
+export class RevokeTokenComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/dashboard/auth/client/show-new-token/show-new-token.component.html
+++ b/src/app/dashboard/auth/client/show-new-token/show-new-token.component.html
@@ -1,0 +1,22 @@
+<h2 mat-dialog-title>Client Access Token</h2>
+<div mat-dialog-content>
+  <mat-form-field class="full-width" appearance="fill">
+    <mat-label>Access Token</mat-label>
+    <input disabled matInput [value]="security.access_token" />
+    <button
+      matTooltip="Copy token"
+      mat-icon-button
+      matSuffix
+      ngxClipboard
+      [cbContent]="security.access_token"
+      [attr.aria-label]="'Copy Token'"
+    >
+      <mat-icon matSuffix>file_copy</mat-icon>
+    </button>
+  </mat-form-field>
+</div>
+<div align="end" mat-dialog-actions>
+  <button (click)="closeDialog()" type="button" color="warn" mat-stroked-button>
+    Close
+  </button>
+</div>

--- a/src/app/dashboard/auth/client/show-new-token/show-new-token.component.scss
+++ b/src/app/dashboard/auth/client/show-new-token/show-new-token.component.scss
@@ -1,0 +1,3 @@
+.full-width {
+  width: 100%;
+}

--- a/src/app/dashboard/auth/client/show-new-token/show-new-token.component.spec.ts
+++ b/src/app/dashboard/auth/client/show-new-token/show-new-token.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShowNewTokenComponent } from './show-new-token.component';
+
+describe('ShowNewTokenComponent', () => {
+  let component: ShowNewTokenComponent;
+  let fixture: ComponentFixture<ShowNewTokenComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ShowNewTokenComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShowNewTokenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/show-new-token/show-new-token.component.ts
+++ b/src/app/dashboard/auth/client/show-new-token/show-new-token.component.ts
@@ -1,0 +1,23 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+@Component({
+  selector: 'show-new-token',
+  templateUrl: './show-new-token.component.html',
+  styleUrls: ['./show-new-token.component.scss'],
+})
+export class ShowNewTokenComponent implements OnInit {
+  hide = true;
+  errorMessage!: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<ShowNewTokenComponent>,
+    @Inject(MAT_DIALOG_DATA) public security: { access_token: string }
+  ) {}
+
+  ngOnInit(): void {}
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/client/show-secret/show-secret.component.html
+++ b/src/app/dashboard/auth/client/show-secret/show-secret.component.html
@@ -1,0 +1,28 @@
+<h2 mat-dialog-title>Client secret for {{ client.name }}</h2>
+<div mat-dialog-content>
+  <div class="loading-shade" *ngIf="!clientSecret">
+    <mat-spinner *ngIf="!clientSecret"></mat-spinner>
+  </div>
+  <mat-form-field *ngIf="clientSecret" class="full-width" appearance="fill">
+    <mat-label>Client secret</mat-label>
+    <input
+      [type]="hide ? 'password' : 'text'"
+      disabled
+      matInput
+      [value]="clientSecret"
+    />
+    <button
+      matTooltip="Show secret"
+      mat-icon-button
+      matSuffix
+      (click)="hide = !hide"
+    >
+      <mat-icon>{{ hide ? "visibility_off" : "visibility" }}</mat-icon>
+    </button>
+  </mat-form-field>
+</div>
+<div align="end" mat-dialog-actions>
+  <button (click)="closeDialog()" type="button" color="warn" mat-stroked-button>
+    Close
+  </button>
+</div>

--- a/src/app/dashboard/auth/client/show-secret/show-secret.component.scss
+++ b/src/app/dashboard/auth/client/show-secret/show-secret.component.scss
@@ -1,0 +1,15 @@
+.full-width {
+  width: 100%;
+}
+.loading-shade {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 56px;
+  right: 0;
+  background: rgba(0, 0, 0, 0.15);
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/app/dashboard/auth/client/show-secret/show-secret.component.spec.ts
+++ b/src/app/dashboard/auth/client/show-secret/show-secret.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShowSecretComponent } from './show-secret.component';
+
+describe('ShowSecretComponent', () => {
+  let component: ShowSecretComponent;
+  let fixture: ComponentFixture<ShowSecretComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ShowSecretComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShowSecretComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/show-secret/show-secret.component.ts
+++ b/src/app/dashboard/auth/client/show-secret/show-secret.component.ts
@@ -1,0 +1,48 @@
+import { Subscription } from 'rxjs';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Client, ClientService } from 'src/app/dashboard/services/client.service';
+
+@Component({
+  selector: 'show-secret',
+  templateUrl: './show-secret.component.html',
+  styleUrls: ['./show-secret.component.scss'],
+})
+export class ShowSecretComponent implements OnInit, OnDestroy {
+  hide = true;
+  clientSecret!: string;
+  errorMessage!: string;
+  subscription!: Subscription;
+
+  constructor(
+    private clientService: ClientService,
+    public dialogRef: MatDialogRef<ShowSecretComponent>,
+    @Inject(MAT_DIALOG_DATA) public client: Client
+  ) {}
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+
+  ngOnInit(): void {
+    this.dialogRef.disableClose = true;
+    this.subscription = this.clientService.getSecret(this.client.id).subscribe({
+      error: (err) => {
+        this.dialogRef.disableClose = false;
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: (res) => {
+        this.dialogRef.disableClose = false;
+        this.clientSecret = res.content.clientSecret;
+      },
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/client/show-token/show-token.component.html
+++ b/src/app/dashboard/auth/client/show-token/show-token.component.html
@@ -1,0 +1,44 @@
+<h2 mat-dialog-title>Created client data</h2>
+<div mat-dialog-content>
+  <mat-form-field class="full-width" appearance="fill">
+    <mat-label>Client Id</mat-label>
+    <input disabled matInput [value]="clientResult.clientId" />
+  </mat-form-field>
+  <mat-form-field class="full-width" appearance="fill">
+    <mat-label>Client secret</mat-label>
+    <input disabled matInput [value]="clientResult.clientSecret" />
+    <button
+      matTooltip="Copy secret"
+      mat-icon-button
+      matSuffix
+      ngxClipboard
+      [cbContent]="clientResult.clientSecret"
+      [attr.aria-label]="'Copy Token'"
+    >
+      <mat-icon matSuffix>file_copy</mat-icon>
+    </button>
+  </mat-form-field>
+  <mat-form-field
+    *ngIf="!(clientResult.access_token === '')"
+    class="full-width"
+    appearance="fill"
+  >
+    <mat-label>Access Token</mat-label>
+    <input disabled matInput [value]="clientResult.access_token" />
+    <button
+      matTooltip="Copy token"
+      mat-icon-button
+      matSuffix
+      ngxClipboard
+      [cbContent]="clientResult.access_token"
+      [attr.aria-label]="'Copy Token'"
+    >
+      <mat-icon matSuffix>file_copy</mat-icon>
+    </button>
+  </mat-form-field>
+</div>
+<div align="end" mat-dialog-actions>
+  <button (click)="closeDialog()" type="button" color="warn" mat-stroked-button>
+    Ok
+  </button>
+</div>

--- a/src/app/dashboard/auth/client/show-token/show-token.component.scss
+++ b/src/app/dashboard/auth/client/show-token/show-token.component.scss
@@ -1,0 +1,3 @@
+.full-width {
+  width: 100%;
+}

--- a/src/app/dashboard/auth/client/show-token/show-token.component.spec.ts
+++ b/src/app/dashboard/auth/client/show-token/show-token.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ShowTokenComponent } from './show-token.component';
+
+describe('ShowTokenComponent', () => {
+  let component: ShowTokenComponent;
+  let fixture: ComponentFixture<ShowTokenComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ShowTokenComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ShowTokenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/show-token/show-token.component.ts
+++ b/src/app/dashboard/auth/client/show-token/show-token.component.ts
@@ -1,0 +1,21 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ClientCreateContent } from 'src/app/dashboard/services/client.service';
+
+@Component({
+  selector: 'show-token',
+  templateUrl: './show-token.component.html',
+  styleUrls: ['./show-token.component.scss'],
+})
+export class ShowTokenComponent implements OnInit {
+  constructor(
+    public dialogRef: MatDialogRef<ShowTokenComponent>,
+    @Inject(MAT_DIALOG_DATA) public clientResult: ClientCreateContent
+  ) {}
+
+  ngOnInit(): void {}
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/client/update-client/update-client.component.html
+++ b/src/app/dashboard/auth/client/update-client/update-client.component.html
@@ -1,0 +1,33 @@
+<h2 mat-dialog-title>Update Client {{ client.name }}</h2>
+<form
+  [formGroup]="updateUserForm"
+  (ngSubmit)="updateUser(updateUserForm.value)"
+>
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" name="name" required />
+      <mat-hint>Put your name</mat-hint>
+    </mat-form-field>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!updateUserForm.valid || dialogRef.disableClose"
+      color="primary"
+      mat-flat-button
+    >
+      Update
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/client/update-client/update-client.component.scss
+++ b/src/app/dashboard/auth/client/update-client/update-client.component.scss
@@ -1,0 +1,40 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}
+
+.select-role {
+  display: grid;
+  grid-template-columns: auto 0.15fr;
+  gap: 0.5rem;
+  button {
+    height: 59.5px;
+  }
+  margin-bottom: 1rem;
+}
+
+.roles-list {
+  display: grid;
+  grid-template-columns: auto 0.1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  .role-title {
+    border-radius: 0.25rem;
+    background-color: rgba(130, 199, 255, 0.267);
+    h3 {
+      margin: 0;
+    }
+    padding: 1rem;
+  }
+}

--- a/src/app/dashboard/auth/client/update-client/update-client.component.spec.ts
+++ b/src/app/dashboard/auth/client/update-client/update-client.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UpdateClientComponent } from './update-client.component';
+
+describe('UpdateClientComponent', () => {
+  let component: UpdateClientComponent;
+  let fixture: ComponentFixture<UpdateClientComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ UpdateClientComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UpdateClientComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/update-client/update-client.component.ts
+++ b/src/app/dashboard/auth/client/update-client/update-client.component.ts
@@ -1,0 +1,59 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Client, ClientService, ClientUpdateBody } from 'src/app/dashboard/services/client.service';
+
+
+@Component({
+  selector: 'update-client',
+  templateUrl: './update-client.component.html',
+  styleUrls: ['./update-client.component.scss'],
+})
+export class UpdateClientComponent implements OnInit {
+  errorMessage!: string;
+  updateUserForm: FormGroup;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    public dialogRef: MatDialogRef<UpdateClientComponent>,
+    private clientService: ClientService,
+    @Inject(MAT_DIALOG_DATA) public client: Client
+  ) {
+    this.updateUserForm = this.formBuilder.group({
+      name: this.formBuilder.control(
+        client.name,
+        Validators.compose([
+          Validators.required,
+          Validators.minLength(4),
+          Validators.maxLength(45),
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/\s]+$/),
+        ])
+      ),
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  updateUser(updateClientData: ClientUpdateBody) {
+    this.dialogRef.disableClose = true;
+    this.clientService
+      .updateClient(this.client.subjectId, updateClientData)
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/dashboard/auth/client/view-client-roles/view-client-roles.component.html
+++ b/src/app/dashboard/auth/client/view-client-roles/view-client-roles.component.html
@@ -1,0 +1,35 @@
+<h2 class="primary-color" mat-dialog-title>{{ userTitle }}</h2>
+<div mat-dialog-content>
+  <div class="accordion-container">
+    <mat-accordion>
+      <mat-expansion-panel *ngFor="let role of client.roles">
+        <mat-expansion-panel-header>
+          <mat-panel-title> {{ role.identifier }} </mat-panel-title>
+        </mat-expansion-panel-header>
+        <h4>Grouped by application resource</h4>
+        <mat-list>
+          <div *ngFor="let option of role.resources">
+            <div mat-subheader>{{ option.applicationResourceName }}</div>
+            <mat-list-item *ngFor="let allowed of option.allowed">
+              <mat-icon mat-list-icon>vpn_key</mat-icon>
+              <div mat-line>
+                {{ option.applicationResourceName }}:{{ allowed }}
+              </div>
+            </mat-list-item>
+            <mat-divider></mat-divider>
+          </div>
+        </mat-list>
+      </mat-expansion-panel>
+    </mat-accordion>
+  </div>
+</div>
+<div align="end" mat-dialog-actions>
+  <button
+    (click)="closeDialog()"
+    type="button"
+    color="primary"
+    mat-stroked-button
+  >
+    Ok
+  </button>
+</div>

--- a/src/app/dashboard/auth/client/view-client-roles/view-client-roles.component.spec.ts
+++ b/src/app/dashboard/auth/client/view-client-roles/view-client-roles.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewClientRolesComponent } from './view-client-roles.component';
+
+describe('ViewClientRolesComponent', () => {
+  let component: ViewClientRolesComponent;
+  let fixture: ComponentFixture<ViewClientRolesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ViewClientRolesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewClientRolesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/client/view-client-roles/view-client-roles.component.ts
+++ b/src/app/dashboard/auth/client/view-client-roles/view-client-roles.component.ts
@@ -1,0 +1,25 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Client } from 'src/app/dashboard/services/client.service';
+
+@Component({
+  selector: 'lib-view-client-roles',
+  templateUrl: './view-client-roles.component.html',
+  styleUrls: ['./view-client-roles.component.scss'],
+})
+export class ViewClientRolesComponent implements OnInit {
+  userTitle: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<ViewClientRolesComponent>,
+    @Inject(MAT_DIALOG_DATA) public client: Client
+  ) {
+    this.userTitle = `${client.name} roles`;
+  }
+
+  ngOnInit(): void {}
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/role/create-role/create-role.component.html
+++ b/src/app/dashboard/auth/role/create-role/create-role.component.html
@@ -1,0 +1,67 @@
+<h2 mat-dialog-title>Create Role</h2>
+<form
+  [formGroup]="createRoleForm"
+  (ngSubmit)="createRole(createRoleForm.value)"
+>
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Identifier</mat-label>
+      <input
+        matInput
+        placeholder="admin01"
+        formControlName="identifier"
+        name="identifier"
+        required
+      />
+      <mat-hint>A role identifier</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Select a resource</mat-label>
+      <mat-select name="resource" formControlName="resource">
+        <mat-option
+          [value]="option.applicationResourceName"
+          *ngFor="let option of options"
+          >{{ option.applicationResourceName }}</mat-option
+        >
+      </mat-select>
+      <mat-hint>Select an application resource</mat-hint>
+    </mat-form-field>
+    <mat-selection-list #allowed formControlName="selected">
+      <mat-list-option
+        [value]="allowedL"
+        [disabled]="
+          allowedL.allowed !== '*' &&
+          createRoleForm.get('selected')?.value.length ===
+            allowedShowList.length
+            ? true
+            : false
+        "
+        *ngFor="let allowedL of allowedShowList"
+      >
+        {{ allowedL.allowed }}
+      </mat-list-option>
+    </mat-selection-list>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="
+        !createRoleForm.valid || objectKeys(allowedObject).length === 0
+      "
+      color="primary"
+      mat-flat-button
+    >
+      Create
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/role/create-role/create-role.component.scss
+++ b/src/app/dashboard/auth/role/create-role/create-role.component.scss
@@ -1,0 +1,4 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/src/app/dashboard/auth/role/create-role/create-role.component.spec.ts
+++ b/src/app/dashboard/auth/role/create-role/create-role.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateRoleComponent } from './create-role.component';
+
+describe('CreateRoleComponent', () => {
+  let component: CreateRoleComponent;
+  let fixture: ComponentFixture<CreateRoleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CreateRoleComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CreateRoleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/role/create-role/create-role.component.ts
+++ b/src/app/dashboard/auth/role/create-role/create-role.component.ts
@@ -1,0 +1,196 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { Subscription } from 'rxjs';
+import { Option, Resource, ResourceService } from 'src/app/dashboard/services/resource.service';
+import { RoleService } from 'src/app/dashboard/services/role.service';
+
+@Component({
+  selector: 'lib-create-role',
+  templateUrl: './create-role.component.html',
+  styleUrls: ['./create-role.component.scss'],
+})
+export class CreateRoleComponent implements OnInit, OnDestroy {
+  createRoleForm: FormGroup;
+  errorMessage!: string;
+  options: Resource[] = [];
+  allowedShowList: Option[] = [];
+  allowedObject: Record<string, Option[]> = {};
+  objectKeys = Object.keys;
+
+  selectedSubscription: Subscription;
+  resourceSubscription: Subscription;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    private roleService: RoleService,
+    private resourceService: ResourceService,
+    public dialogRef: MatDialogRef<CreateRoleComponent>
+  ) {
+    this.resourceService.getResourcesBasic().subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+        this.options = [];
+      },
+      next: (res) => {
+        this.options = res.content || [];
+      },
+    });
+    this.createRoleForm = this.formBuilder.group({
+      identifier: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/]+$/),
+          Validators.minLength(4),
+          Validators.maxLength(20),
+        ])
+      ),
+      resource: this.formBuilder.control(''),
+      selected: this.formBuilder.control(''),
+    });
+    this.resourceSubscription = this.createRoleForm
+      .get('resource')
+      ?.valueChanges.subscribe({
+        next: (value: string) => {
+          this.allowedShowList =
+            this.options.find((o) => o.applicationResourceName === value)
+              ?.allowed || [];
+          this.createRoleForm
+            .get('selected')
+            ?.setValue(this.allowedObject[value] || []);
+        },
+      }) as Subscription;
+
+    this.selectedSubscription = this.createRoleForm
+      .get('selected')
+      ?.valueChanges.subscribe((valueChange: Option[]) => {
+        const currentAllowedObject =
+          this.allowedObject[this.createRoleForm.get('resource')?.value] || [];
+
+        if (valueChange.length === 0 && currentAllowedObject.length === 0)
+          return;
+
+        let newOptionEntry: Option;
+
+        if (currentAllowedObject.length === 0) {
+          newOptionEntry = valueChange[0];
+          this.selectedChange(true, newOptionEntry);
+          return;
+        }
+
+        if (valueChange.length === 0) {
+          newOptionEntry = currentAllowedObject[0];
+          this.selectedChange(false, newOptionEntry);
+          return;
+        }
+
+        if (
+          currentAllowedObject[0].allowed === '*' &&
+          valueChange[0].allowed !== '*'
+        ) {
+          newOptionEntry = currentAllowedObject[0];
+          this.selectedChange(false, newOptionEntry);
+          return;
+        }
+
+        if (valueChange[0].allowed === '*') {
+          newOptionEntry = valueChange[0];
+          this.selectedChange(true, newOptionEntry);
+          return;
+        }
+
+        if (currentAllowedObject.length > valueChange.length) {
+          for (const allowed of currentAllowedObject) {
+            const indexOfAllowed = valueChange.findIndex(
+              (v) => v.id === allowed.id
+            );
+
+            if (indexOfAllowed === -1) {
+              newOptionEntry = allowed;
+              this.selectedChange(false, newOptionEntry);
+              break;
+            }
+          }
+
+          return;
+        }
+
+        for (const value of valueChange) {
+          const indexOfAllowed = currentAllowedObject.findIndex(
+            (c) => c.id === value.id
+          );
+
+          if (indexOfAllowed === -1) {
+            newOptionEntry = value;
+            this.selectedChange(true, newOptionEntry);
+            break;
+          }
+        }
+      }) as Subscription;
+  }
+
+  ngOnDestroy(): void {
+    this.resourceSubscription?.unsubscribe();
+    this.selectedSubscription?.unsubscribe();
+  }
+
+  ngOnInit(): void {}
+
+  createRole(roleBody: { identifier: string; resource: string | undefined }) {
+    this.roleService
+      .createRole(roleBody.identifier, this.allowedObject)
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+
+  selectedChange(selected: boolean, value: Option) {
+    // const currentAllowedObject =
+    //   this.allowedObject[this.createRoleForm.get('resource')?.value];
+    if (
+      value.allowed === '*' &&
+      selected &&
+      this.createRoleForm.get('selected')?.value.length !==
+        this.allowedShowList.length
+    ) {
+      this.createRoleForm.get('selected')?.setValue(this.allowedShowList);
+      this.allowedObject[this.createRoleForm.get('resource')?.value] = [
+        this.allowedShowList[0],
+      ];
+    } else if (value.allowed === '*' && !selected) {
+      const temporalAllowed = [...this.allowedShowList];
+      temporalAllowed.shift();
+      this.allowedObject[this.createRoleForm.get('resource')?.value] =
+        temporalAllowed;
+    } else if (selected) {
+      this.allowedObject[this.createRoleForm.get('resource')?.value] =
+        this.createRoleForm.get('selected')?.value;
+    } else {
+      if (this.createRoleForm.get('selected')?.value.length === 0) {
+        delete this.allowedObject[this.createRoleForm.get('resource')?.value];
+      } else {
+        this.allowedObject[this.createRoleForm.get('resource')?.value] =
+          this.createRoleForm.get('selected')?.value;
+      }
+    }
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/role/delete-role/delete-role.component.html
+++ b/src/app/dashboard/auth/role/delete-role/delete-role.component.html
@@ -1,0 +1,26 @@
+<h2 mat-dialog-title>Delete Role {{ role.identifier }}</h2>
+<div mat-dialog-content>
+  <div class="error-display" *ngIf="errorMessage">
+    <h5>{{ errorMessage }}</h5>
+  </div>
+  <p>Are you sure?</p>
+</div>
+<div align="end" mat-dialog-actions>
+  <button
+    (click)="closeDialog()"
+    type="button"
+    color="warn"
+    mat-stroked-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Cancel</button
+  ><button
+    (click)="delete()"
+    type="button"
+    color="primary"
+    mat-flat-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Delete
+  </button>
+</div>

--- a/src/app/dashboard/auth/role/delete-role/delete-role.component.spec.ts
+++ b/src/app/dashboard/auth/role/delete-role/delete-role.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteRoleComponent } from './delete-role.component';
+
+describe('DeleteRoleComponent', () => {
+  let component: DeleteRoleComponent;
+  let fixture: ComponentFixture<DeleteRoleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeleteRoleComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteRoleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/role/delete-role/delete-role.component.ts
+++ b/src/app/dashboard/auth/role/delete-role/delete-role.component.ts
@@ -1,0 +1,41 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Role, RoleService } from 'src/app/dashboard/services/role.service';
+
+@Component({
+  selector: 'lib-delete-role',
+  templateUrl: './delete-role.component.html',
+  styleUrls: ['./delete-role.component.scss'],
+})
+export class DeleteRoleComponent implements OnInit {
+  errorMessage!: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<DeleteRoleComponent>,
+    private roleService: RoleService,
+    @Inject(MAT_DIALOG_DATA) public role: Role
+  ) {}
+
+  ngOnInit(): void {}
+
+  delete() {
+    this.dialogRef.disableClose = true;
+    this.roleService.deleteRole(this.role.id).subscribe({
+      error: (err) => {
+        this.dialogRef.disableClose = false;
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.dialogRef.close(true);
+      },
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/role/options/options.component.html
+++ b/src/app/dashboard/auth/role/options/options.component.html
@@ -1,0 +1,50 @@
+<h2 mat-dialog-title>Role {{ role.identifier }} access options</h2>
+<form [formGroup]="optionsForm" (ngSubmit)="updateOptions()">
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Select a resource</mat-label>
+      <mat-select name="resource" formControlName="resource">
+        <mat-option
+          [value]="option.applicationResourceName"
+          *ngFor="let option of options"
+          >{{ option.applicationResourceName }}</mat-option
+        >
+      </mat-select>
+      <mat-hint>Select an application resource</mat-hint>
+    </mat-form-field>
+    <mat-selection-list #allowed formControlName="selected">
+      <mat-list-option
+        [value]="convertToString(allowedL)"
+        [disabled]="
+          allowedL.allowed !== '*' &&
+          optionsForm.get('selected')?.value.length === allowedShowList.length
+            ? true
+            : false
+        "
+        *ngFor="let allowedL of allowedShowList"
+      >
+        {{ allowedL.allowed }}
+      </mat-list-option>
+    </mat-selection-list>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!optionsForm.valid || objectKeys(allowedObject).length === 0"
+      color="primary"
+      mat-flat-button
+    >
+      Update
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/role/options/options.component.scss
+++ b/src/app/dashboard/auth/role/options/options.component.scss
@@ -1,0 +1,4 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/src/app/dashboard/auth/role/options/options.component.spec.ts
+++ b/src/app/dashboard/auth/role/options/options.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OptionsComponent } from './options.component';
+
+describe('OptionsComponent', () => {
+  let component: OptionsComponent;
+  let fixture: ComponentFixture<OptionsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ OptionsComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OptionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/role/options/options.component.ts
+++ b/src/app/dashboard/auth/role/options/options.component.ts
@@ -3,7 +3,7 @@ import { FormGroup, FormBuilder } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
 import { Option, Resource, ResourceService } from 'src/app/dashboard/services/resource.service';
-import { Role } from 'src/app/dashboard/services/role.service';
+import { Role, RoleService } from 'src/app/dashboard/services/role.service';
 
 @Component({
   selector: 'lib-options',
@@ -27,6 +27,7 @@ export class OptionsComponent implements OnInit, OnDestroy {
     public dialogRef: MatDialogRef<OptionsComponent>,
     @Inject(MAT_DIALOG_DATA) public role: Role,
     private resourceService: ResourceService,
+    private roleService: RoleService,
     private formBuilder: FormBuilder
   ) {
     for (const option of this.role.resources) {
@@ -190,7 +191,7 @@ export class OptionsComponent implements OnInit, OnDestroy {
   }
 
   updateOptions() {
-    this.resourceService
+    this.roleService
       .updateRoleOptions(
         this.role.id,
         this.allowedObject,

--- a/src/app/dashboard/auth/role/options/options.component.ts
+++ b/src/app/dashboard/auth/role/options/options.component.ts
@@ -1,0 +1,213 @@
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Subscription } from 'rxjs';
+import { Option, Resource, ResourceService } from 'src/app/dashboard/services/resource.service';
+import { Role } from 'src/app/dashboard/services/role.service';
+
+@Component({
+  selector: 'lib-options',
+  templateUrl: './options.component.html',
+  styleUrls: ['./options.component.scss'],
+})
+export class OptionsComponent implements OnInit, OnDestroy {
+  optionsForm: FormGroup;
+  errorMessage!: string;
+  options: Resource[] = [];
+  allowedShowList: Option[] = [];
+  allowedObject: Record<string, Option[]> = {};
+  originalAllowedObject: Record<string, Option[]> = {};
+  objectKeys = Object.keys;
+  convertToString = JSON.stringify;
+
+  selectedSubscription: Subscription;
+  resourceSubscription: Subscription;
+
+  constructor(
+    public dialogRef: MatDialogRef<OptionsComponent>,
+    @Inject(MAT_DIALOG_DATA) public role: Role,
+    private resourceService: ResourceService,
+    private formBuilder: FormBuilder
+  ) {
+    for (const option of this.role.resources) {
+      this.allowedObject[option.applicationResourceName] = [...option.allowed];
+      this.originalAllowedObject[option.applicationResourceName] = [
+        ...option.allowed,
+      ];
+    }
+
+    this.resourceService.getResourcesBasic().subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+        this.options = [];
+      },
+      next: (res) => {
+        this.options = res.content || [];
+      },
+    });
+    this.optionsForm = this.formBuilder.group({
+      resource: this.formBuilder.control(''),
+      selected: this.formBuilder.control([]),
+    });
+    this.resourceSubscription = this.optionsForm
+      .get('resource')
+      ?.valueChanges.subscribe({
+        next: (value) => {
+          this.allowedShowList =
+            this.options.find((o) => o.applicationResourceName === value)
+              ?.allowed || [];
+
+          this.optionsForm
+            .get('selected')
+            ?.setValue(
+              this.allowedObject[this.optionsForm.get('resource')?.value]?.map(
+                (asl) => JSON.stringify(asl)
+              ) || []
+            );
+        },
+      }) as Subscription;
+
+    this.selectedSubscription = this.optionsForm
+      .get('selected')
+      ?.valueChanges.subscribe((valueChange: string[]) => {
+        const currentAllowedObject =
+          this.allowedObject[this.optionsForm.get('resource')?.value] || [];
+
+        if (valueChange.length === 0 && currentAllowedObject.length === 0)
+          return;
+
+        let newOptionEntry: Option;
+
+        if (currentAllowedObject.length === 0) {
+          newOptionEntry = JSON.parse(valueChange[0]);
+          this.selectedChange(true, newOptionEntry);
+          return;
+        }
+
+        if (valueChange.length === 0) {
+          newOptionEntry = currentAllowedObject[0];
+          this.selectedChange(false, newOptionEntry);
+          return;
+        }
+
+        if (
+          currentAllowedObject[0].allowed === '*' &&
+          JSON.parse(valueChange[0]).allowed !== '*'
+        ) {
+          newOptionEntry = currentAllowedObject[0];
+          this.selectedChange(false, newOptionEntry);
+          return;
+        }
+
+        if (JSON.parse(valueChange[0]).allowed === '*') {
+          newOptionEntry = JSON.parse(valueChange[0]);
+          this.selectedChange(true, newOptionEntry);
+          return;
+        }
+
+        if (currentAllowedObject.length > valueChange.length) {
+          for (const allowed of currentAllowedObject) {
+            const indexOfAllowed = valueChange.findIndex(
+              (v) => JSON.parse(v).id === allowed.id
+            );
+
+            if (indexOfAllowed === -1) {
+              newOptionEntry = allowed;
+              this.selectedChange(false, newOptionEntry);
+              break;
+            }
+          }
+
+          return;
+        }
+
+        for (const value of valueChange) {
+          const indexOfAllowed = currentAllowedObject.findIndex(
+            (c) => c.id === JSON.parse(value).id
+          );
+
+          if (indexOfAllowed === -1) {
+            newOptionEntry = JSON.parse(value);
+            this.selectedChange(true, newOptionEntry);
+            break;
+          }
+        }
+      }) as Subscription;
+  }
+
+  ngOnInit(): void {}
+
+  ngOnDestroy(): void {
+    this.resourceSubscription?.unsubscribe();
+    this.selectedSubscription?.unsubscribe();
+  }
+
+  selectedChange(selected: boolean, value: Option) {
+    if (
+      value.allowed === '*' &&
+      selected &&
+      this.optionsForm.get('selected')?.value.length !==
+        this.allowedShowList.length
+    ) {
+      this.optionsForm
+        .get('selected')
+        ?.setValue(
+          this.allowedShowList.map((aso) => JSON.stringify(aso)) || []
+        );
+      this.allowedObject[this.optionsForm.get('resource')?.value] = [
+        this.allowedShowList[0],
+      ];
+    } else if (value.allowed === '*' && !selected) {
+      const temporalAllowed = [...this.allowedShowList];
+      temporalAllowed.shift();
+      this.allowedObject[this.optionsForm.get('resource')?.value] =
+        temporalAllowed;
+    } else if (selected) {
+      this.allowedObject[this.optionsForm.get('resource')?.value] = (
+        this.optionsForm.get('selected')?.value as string[]
+      ).map((stringObj) => {
+        return JSON.parse(stringObj);
+      });
+    } else {
+      if (this.optionsForm.get('selected')?.value.length === 0) {
+        delete this.allowedObject[this.optionsForm.get('resource')?.value];
+      } else {
+        this.allowedObject[this.optionsForm.get('resource')?.value] = (
+          this.optionsForm.get('selected')?.value as string[]
+        ).map((stringObj) => {
+          return JSON.parse(stringObj);
+        });
+      }
+    }
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  updateOptions() {
+    this.resourceService
+      .updateRoleOptions(
+        this.role.id,
+        this.allowedObject,
+        this.originalAllowedObject
+      )
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/role/role.component.html
+++ b/src/app/dashboard/auth/role/role.component.html
@@ -1,0 +1,74 @@
+<div class="role-container">
+  <div class="role-head">
+    <h1 class="role-title">Roles</h1>
+    <span class="separator"></span>
+    <button (click)="openCreateRoleDialog()" color="accent" mat-flat-button>
+      Add Role
+    </button>
+  </div>
+  <div class="role-body">
+    <div class="container-table mat-elevation-z8">
+      <div class="loading-shade" *ngIf="isLoadingResults">
+        <mat-spinner *ngIf="isLoadingResults"></mat-spinner>
+      </div>
+
+      <div class="example-table-container">
+        <table
+          mat-table
+          [dataSource]="roles"
+          class="user-table"
+          matSort
+          matSortActive="id"
+          matSortDisableClear
+          matSortDirection="asc"
+        >
+          <ng-container matColumnDef="id">
+            <th mat-sort-header mat-header-cell *matHeaderCellDef>id</th>
+            <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="identifier">
+            <th mat-header-cell *matHeaderCellDef>Identifier</th>
+            <td mat-cell *matCellDef="let row">{{ row.identifier }}</td>
+          </ng-container>
+
+          <ng-container matColumnDef="options">
+            <th mat-header-cell *matHeaderCellDef>Options</th>
+            <td class="roles-column" mat-cell *matCellDef="let row">
+              <button
+                [disabled]="row.identifier === 'admin'"
+                (click)="openOptionsDialog(row)"
+                mat-stroked-button
+              >
+                Options
+              </button>
+            </td>
+          </ng-container>
+
+          <ng-container matColumnDef="delete">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td class="actions-column" mat-cell *matCellDef="let row">
+              <button
+                color="warn"
+                [disabled]="row.identifier === 'admin'"
+                mat-stroked-button
+                (click)="openDeleteRoleDialog(row)"
+              >
+                Delete Role
+              </button>
+            </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+        </table>
+      </div>
+
+      <mat-paginator
+        [length]="resultsLength"
+        [pageSize]="20"
+        aria-label="Select page of GitHub search results"
+      ></mat-paginator>
+    </div>
+  </div>
+</div>

--- a/src/app/dashboard/auth/role/role.component.scss
+++ b/src/app/dashboard/auth/role/role.component.scss
@@ -1,0 +1,52 @@
+.role-container {
+  .role-head {
+    .separator {
+      flex: 1 0;
+    }
+
+    .role-title {
+      margin: 0;
+      font-size: 32px;
+    }
+
+    display: flex;
+
+    margin-bottom: 2rem;
+  }
+
+  table {
+    width: 100%;
+    th,
+    td {
+      width: 20%;
+    }
+    .roles-column {
+      button:last-child {
+        margin-left: 0.5rem;
+      }
+    }
+    .actions-column {
+      text-align: end;
+      button:last-child {
+        margin-left: 0.5rem;
+      }
+    }
+  }
+
+  .container-table {
+    position: relative;
+  }
+
+  .loading-shade {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 56px;
+    right: 0;
+    background: rgba(0, 0, 0, 0.15);
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/src/app/dashboard/auth/role/role.component.spec.ts
+++ b/src/app/dashboard/auth/role/role.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RoleComponent } from './role.component';
+
+describe('OauthStarterRolesComponent', () => {
+  let component: RoleComponent;
+  let fixture: ComponentFixture<RoleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RoleComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RoleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/role/role.component.ts
+++ b/src/app/dashboard/auth/role/role.component.ts
@@ -1,0 +1,144 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import {
+  BehaviorSubject,
+  Subscription,
+  merge,
+  startWith,
+  switchMap,
+  catchError,
+  of,
+  map,
+  first,
+} from 'rxjs';
+import { BasicRole, Role, RoleService } from '../../services/role.service';
+import { CreateRoleComponent } from './create-role/create-role.component';
+import { DeleteRoleComponent } from './delete-role/delete-role.component';
+import { OptionsComponent } from './options/options.component';
+
+@Component({
+  selector: 'starter-roles',
+  templateUrl: './role.component.html',
+  styleUrls: ['./role.component.scss'],
+})
+export class RoleComponent implements OnInit {
+  roles!: BasicRole[];
+  errorMessage!: string | undefined;
+  displayedColumns: string[] = ['id', 'identifier', 'options', 'delete'];
+
+  resultsLength = 0;
+  isLoadingResults = true;
+
+  reload = new BehaviorSubject<number>(0);
+
+  roleDataSubscription!: Subscription;
+
+  @ViewChild(MatPaginator) paginator!: MatPaginator;
+  @ViewChild(MatSort) sort!: MatSort;
+
+  constructor(
+    private roleService: RoleService,
+    public dialog: MatDialog
+  ) {}
+
+  ngOnInit(): void {}
+
+  ngOnDestroy(): void {
+    this.roleDataSubscription?.unsubscribe();
+    this.sort.sortChange.complete();
+  }
+
+  ngAfterViewInit(): void {
+    this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
+    this.roleDataSubscription = merge(
+      this.sort.sortChange,
+      this.paginator.page,
+      this.reload
+    )
+      .pipe(
+        startWith({}),
+        switchMap(() => {
+          this.errorMessage = undefined;
+          this.isLoadingResults = true;
+          return this.roleService
+            .getRoles(this.paginator.pageIndex, this.sort.direction)
+            .pipe(
+              catchError((err) => {
+                if (err.error) {
+                  this.errorMessage = err.error.message;
+                } else {
+                  this.errorMessage = 'Unknown Error';
+                }
+                return of(null);
+              })
+            );
+        }),
+        map((data) => {
+          this.isLoadingResults = false;
+          if (data === null) {
+            return [];
+          }
+          this.resultsLength = data.content?.totalItems || 0;
+          return data.content?.items || [];
+        })
+      )
+      .subscribe((data) => {
+        this.roles = data;
+      });
+  }
+
+  openCreateRoleDialog() {
+    const createRoleDialogRef = this.dialog.open(CreateRoleComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+    });
+    createRoleDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+
+  openOptionsDialog(role: Role) {
+    const optionsRoleDialogRef = this.dialog.open(OptionsComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: role,
+    });
+    optionsRoleDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+
+  openDeleteRoleDialog(role: Role) {
+    const deleteRoleDialogRef = this.dialog.open(DeleteRoleComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: role,
+    });
+    deleteRoleDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/user-profile/change-password/change-password.component.html
+++ b/src/app/dashboard/auth/user-profile/change-password/change-password.component.html
@@ -1,0 +1,74 @@
+<h2 mat-dialog-title>Change Password</h2>
+<form
+  [formGroup]="changePasswordForm"
+  (ngSubmit)="changePassword(changePasswordForm.value)"
+>
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field appearance="fill" class="forms-field">
+      <mat-label>Old Password</mat-label>
+      <input
+        formControlName="oldPassword"
+        name="oldPassword"
+        matInput
+        [type]="hideOldPassword ? 'password' : 'text'"
+        required
+      />
+      <button
+        type="button"
+        mat-icon-button
+        matSuffix
+        (click)="hideOldPassword = !hideOldPassword"
+        [attr.aria-label]="'hideOldPassword password'"
+        [attr.aria-pressed]="hideOldPassword"
+      >
+        <mat-icon>{{
+          hideOldPassword ? "visibility_off" : "visibility"
+        }}</mat-icon>
+      </button>
+      <mat-hint>Put your current password</mat-hint>
+    </mat-form-field>
+    <mat-form-field appearance="fill" class="forms-field">
+      <mat-label>New Password</mat-label>
+      <input
+        formControlName="newPassword"
+        name="newPassword"
+        matInput
+        [type]="hideNewPassword ? 'password' : 'text'"
+        required
+      />
+      <button
+        type="button"
+        mat-icon-button
+        matSuffix
+        (click)="hideNewPassword = !hideNewPassword"
+        [attr.aria-label]="'hideOldPassword password'"
+        [attr.aria-pressed]="hideNewPassword"
+      >
+        <mat-icon>{{
+          hideNewPassword ? "visibility_off" : "visibility"
+        }}</mat-icon>
+      </button>
+      <mat-hint>Put your new password</mat-hint>
+    </mat-form-field>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!changePasswordForm.valid"
+      color="primary"
+      mat-flat-button
+    >
+      Update
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/user-profile/change-password/change-password.component.scss
+++ b/src/app/dashboard/auth/user-profile/change-password/change-password.component.scss
@@ -1,0 +1,4 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}

--- a/src/app/dashboard/auth/user-profile/change-password/change-password.component.spec.ts
+++ b/src/app/dashboard/auth/user-profile/change-password/change-password.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChangePasswordComponent } from './change-password.component';
+
+describe('ChangePasswordComponent', () => {
+  let component: ChangePasswordComponent;
+  let fixture: ComponentFixture<ChangePasswordComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ChangePasswordComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChangePasswordComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/user-profile/change-password/change-password.component.ts
+++ b/src/app/dashboard/auth/user-profile/change-password/change-password.component.ts
@@ -1,0 +1,91 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { User, UserService } from 'src/app/dashboard/services/user.service';
+
+
+@Component({
+  selector: 'change-password',
+  templateUrl: './change-password.component.html',
+  styleUrls: ['./change-password.component.scss'],
+})
+export class ChangePasswordComponent implements OnInit {
+  changePasswordForm: FormGroup;
+  errorMessage!: string;
+
+  hideNewPassword = true;
+  hideOldPassword = true;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    public dialogRef: MatDialogRef<ChangePasswordComponent>,
+    private userService: UserService,
+    @Inject(MAT_DIALOG_DATA) public user: User
+  ) {
+    this.changePasswordForm = this.formBuilder.group({
+      oldPassword: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[A-Z]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[0-9]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[a-z]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.minLength(6),
+        ])
+      ),
+      newPassword: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[A-Z]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[0-9]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[a-z]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.minLength(6),
+        ])
+      ),
+    });
+  }
+
+  ngOnInit(): void {}
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  changePassword(updatePasswordData: {
+    oldPassword: string;
+    newPassword: string;
+  }) {
+    this.userService
+      .updatePassword(
+        this.user.id,
+        updatePasswordData.newPassword,
+        updatePasswordData.oldPassword
+      )
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/user-profile/user-profile.component.html
+++ b/src/app/dashboard/auth/user-profile/user-profile.component.html
@@ -1,0 +1,38 @@
+<div>
+  <div class="profile-container" *ngIf="user">
+    <div class="header">
+      <h1>{{ user.name }} Profile</h1>
+      <h4>#{{ user.id }}</h4>
+    </div>
+    <section>
+      <h3>Roles</h3>
+      <mat-accordion>
+        <mat-expansion-panel *ngFor="let role of user.roles">
+          <mat-expansion-panel-header>
+            <mat-panel-title>
+              #{{ role.id }} | Role Name: {{ role.identifier }}
+            </mat-panel-title>
+          </mat-expansion-panel-header>
+          <mat-list role="list">
+            <mat-list-item
+              *ngFor="let resource of role.resources"
+              role="listitem"
+              >{{ resource.applicationResourceName }} | Options:
+              {{ resource.allowed.join(",") }}</mat-list-item
+            >
+          </mat-list>
+        </mat-expansion-panel>
+      </mat-accordion>
+      <div class="actions">
+        <button
+          (click)="openChangePasswordDialog()"
+          type="button"
+          mat-flat-button
+          color="accent"
+        >
+          Change Password
+        </button>
+      </div>
+    </section>
+  </div>
+</div>

--- a/src/app/dashboard/auth/user-profile/user-profile.component.scss
+++ b/src/app/dashboard/auth/user-profile/user-profile.component.scss
@@ -1,0 +1,37 @@
+.header {
+  h1 {
+    margin: 0;
+    font-size: 32px;
+  }
+
+  h4 {
+    margin: 0;
+    color: gray;
+  }
+
+  display: flex;
+
+  align-items: baseline;
+  gap: 0.5rem;
+
+  flex-wrap: wrap;
+}
+
+section {
+  display: grid;
+  .roles-list {
+    color: black;
+  }
+
+  .actions {
+    margin-top: 2rem;
+  }
+}
+
+.profile-container ::ng-deep .mat-list-base {
+  .mat-list-item {
+    .mat-list-item-content {
+      color: black;
+    }
+  }
+}

--- a/src/app/dashboard/auth/user-profile/user-profile.component.spec.ts
+++ b/src/app/dashboard/auth/user-profile/user-profile.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UserProfileComponent } from './user-profile.component';
+
+describe('UserProfileComponent', () => {
+  let component: UserProfileComponent;
+  let fixture: ComponentFixture<UserProfileComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ UserProfileComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/user-profile/user-profile.component.ts
+++ b/src/app/dashboard/auth/user-profile/user-profile.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { User, UserService } from '../../services/user.service';
+
+import { ChangePasswordComponent } from './change-password/change-password.component';
+
+@Component({
+  selector: 'user-profile',
+  templateUrl: './user-profile.component.html',
+  styleUrls: ['./user-profile.component.scss'],
+})
+export class UserProfileComponent implements OnInit {
+  user!: User;
+
+  constructor(
+    private userService: UserService,
+    public dialog: MatDialog
+  ) {
+    this.userService.getUserProfile().subscribe({
+      next: (res) => {
+        this.user = res.content as User;
+      },
+    });
+  }
+
+  ngOnInit(): void {}
+
+  openChangePasswordDialog() {
+    this.dialog.open(ChangePasswordComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: this.user,
+    });
+  }
+}

--- a/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.html
+++ b/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.html
@@ -1,0 +1,52 @@
+<h2 mat-dialog-title>Modify roles of {{ user.name }}</h2>
+<form [formGroup]="addRolesForm" (ngSubmit)="updateRoles()">
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <div class="select-role">
+      <mat-form-field class="forms-field" appearance="fill">
+        <mat-label>Select A Role</mat-label>
+        <mat-select name="role" formControlName="role">
+          <mat-option [value]="role" *ngFor="let role of roles">{{
+            role.identifier
+          }}</mat-option>
+        </mat-select>
+        <mat-hint>Select a role and add it</mat-hint>
+      </mat-form-field>
+      <button type="button" (click)="addRoleToList()" mat-stroked-button>
+        +
+      </button>
+    </div>
+    <div *ngFor="let role of rolesList" class="roles-list">
+      <div class="role-title">
+        <h3>{{ role.identifier }}</h3>
+      </div>
+      <button
+        (click)="removeRoleToList(role)"
+        color="warn"
+        type="button"
+        mat-stroked-button
+      >
+        -
+      </button>
+    </div>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!addRolesForm.valid || rolesList.length === 0"
+      color="primary"
+      mat-flat-button
+    >
+      Update
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.scss
+++ b/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.scss
@@ -1,0 +1,40 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}
+
+.select-role {
+  display: grid;
+  grid-template-columns: auto 0.15fr;
+  gap: 0.5rem;
+  button {
+    height: 59.5px;
+  }
+  margin-bottom: 1rem;
+}
+
+.roles-list {
+  display: grid;
+  grid-template-columns: auto 0.1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  .role-title {
+    border-radius: 0.25rem;
+    background-color: rgba(130, 199, 255, 0.267);
+    h3 {
+      margin: 0;
+    }
+    padding: 1rem;
+  }
+}

--- a/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.spec.ts
+++ b/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { AddUserRolesComponent } from './add-user-roles.component';
+
+
+describe('AddUserRolesComponent', () => {
+  let component: AddUserRolesComponent;
+  let fixture: ComponentFixture<AddUserRolesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AddUserRolesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AddUserRolesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.ts
+++ b/src/app/dashboard/auth/user/add-user-roles/add-user-roles.component.ts
@@ -1,0 +1,96 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { BasicRole, RoleService } from 'src/app/dashboard/services/role.service';
+import { User, UserService } from 'src/app/dashboard/services/user.service';
+
+@Component({
+  selector: 'lib-add-user-roles',
+  templateUrl: './add-user-roles.component.html',
+  styleUrls: ['./add-user-roles.component.scss'],
+})
+export class AddUserRolesComponent implements OnInit {
+  addRolesForm: FormGroup;
+  errorMessage!: string;
+  errorMessageRoles!: string;
+  roles: BasicRole[] = [];
+  rolesList: BasicRole[] = [];
+
+  constructor(
+    public dialogRef: MatDialogRef<AddUserRolesComponent>,
+    private formBuilder: FormBuilder,
+    private roleService: RoleService,
+    private userService: UserService,
+    @Inject(MAT_DIALOG_DATA) public user: User
+  ) {
+    this.roleService.getRolesBasic().subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+        this.roles = [];
+      },
+      next: (res) => {
+        const availableRoles = res.content?.flatMap((c) => {
+          const roleExist = user.roles.findIndex((r) => c.id == r.id) as number;
+          if (roleExist === -1) {
+            return c;
+          }
+          this.rolesList.push(c);
+          return [];
+        });
+        this.roles = availableRoles || [];
+      },
+    });
+    this.addRolesForm = this.formBuilder.group({
+      role: this.formBuilder.control(''),
+    });
+  }
+
+  ngOnInit(): void {}
+
+  addRoleToList() {
+    const roleValue = this.addRolesForm.get('role')?.value;
+    if (!roleValue) {
+      return;
+    }
+    const indexOfRole = this.roles.indexOf(roleValue);
+    this.roles.splice(indexOfRole, 1);
+    this.rolesList.push(roleValue);
+    this.addRolesForm.get('role')?.setValue('');
+  }
+
+  removeRoleToList(role: BasicRole) {
+    const roleValue = role;
+    const indexOfRole = this.rolesList.indexOf(roleValue);
+    this.roles.unshift(role);
+    this.rolesList.splice(indexOfRole, 1);
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  updateRoles() {
+    const basicOriginalRoles = this.user.roles.map((rl) => {
+      return { id: rl.id, identifier: rl.identifier };
+    });
+    this.userService
+      .updateUserRoles(this.user.subjectId, this.rolesList, basicOriginalRoles)
+      .subscribe({
+        error: (err) => {
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+          this.roles = [];
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/user/create-user/create-user.component.html
+++ b/src/app/dashboard/auth/user/create-user/create-user.component.html
@@ -1,0 +1,104 @@
+<h2 mat-dialog-title>Create User</h2>
+<form
+  [formGroup]="createUserForm"
+  (ngSubmit)="createUser(createUserForm.value)"
+>
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" name="name" required />
+      <mat-hint>Put your name</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Description</mat-label>
+      <input
+        matInput
+        formControlName="description"
+        name="description"
+        required
+      />
+      <mat-hint>Breve user description</mat-hint>
+    </mat-form-field>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Username</mat-label>
+      <input
+        matInput
+        placeholder="admin01"
+        formControlName="username"
+        name="username"
+        required
+      />
+      <mat-hint>Your username</mat-hint>
+    </mat-form-field>
+    <mat-form-field appearance="fill" class="forms-field">
+      <mat-label>Password</mat-label>
+      <input
+        formControlName="password"
+        name="password"
+        matInput
+        [type]="hidePassword ? 'password' : 'text'"
+        required
+      />
+      <button
+        type="button"
+        mat-icon-button
+        matSuffix
+        (click)="hidePassword = !hidePassword"
+        [attr.aria-label]="'hidePassword password'"
+        [attr.aria-pressed]="hidePassword"
+      >
+        <mat-icon>{{
+          hidePassword ? "visibility_off" : "visibility"
+        }}</mat-icon>
+      </button>
+      <mat-hint>Put your password</mat-hint>
+    </mat-form-field>
+    <div class="select-role">
+      <mat-form-field class="forms-field" appearance="fill">
+        <mat-label>Select A Role</mat-label>
+        <mat-select name="role" formControlName="role">
+          <mat-option [value]="role" *ngFor="let role of roles">{{
+            role.identifier
+          }}</mat-option>
+        </mat-select>
+        <mat-hint>Select a role and add it</mat-hint>
+      </mat-form-field>
+      <button type="button" (click)="addRoleToList()" mat-stroked-button>
+        +
+      </button>
+    </div>
+    <div *ngFor="let role of rolesList" class="roles-list">
+      <div class="role-title">
+        <h3>{{ role.identifier }}</h3>
+      </div>
+      <button
+        (click)="removeRoleToList(role)"
+        color="warn"
+        type="button"
+        mat-stroked-button
+      >
+        -
+      </button>
+    </div>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!createUserForm.valid || rolesList.length === 0"
+      color="primary"
+      mat-flat-button
+    >
+      Create
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/user/create-user/create-user.component.scss
+++ b/src/app/dashboard/auth/user/create-user/create-user.component.scss
@@ -1,0 +1,40 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}
+
+.select-role {
+  display: grid;
+  grid-template-columns: auto 0.15fr;
+  gap: 0.5rem;
+  button {
+    height: 59.5px;
+  }
+  margin-bottom: 1rem;
+}
+
+.roles-list {
+  display: grid;
+  grid-template-columns: auto 0.1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  .role-title {
+    border-radius: 0.25rem;
+    background-color: rgba(130, 199, 255, 0.267);
+    h3 {
+      margin: 0;
+    }
+    padding: 1rem;
+  }
+}

--- a/src/app/dashboard/auth/user/create-user/create-user.component.ts
+++ b/src/app/dashboard/auth/user/create-user/create-user.component.ts
@@ -1,0 +1,135 @@
+import { Component, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { BasicRole, RoleService } from 'src/app/dashboard/services/role.service';
+import { UserService } from 'src/app/dashboard/services/user.service';
+
+@Component({
+  selector: 'create-user',
+  templateUrl: './create-user.component.html',
+  styleUrls: ['./create-user.component.scss'],
+})
+export class CreateUserComponent implements OnInit {
+  createUserForm: FormGroup;
+  errorMessage!: string;
+  errorMessageRoles!: string;
+  roles: BasicRole[] = [];
+  rolesList: BasicRole[] = [];
+  hidePassword = true;
+
+  constructor(
+    public dialogRef: MatDialogRef<CreateUserComponent>,
+    private formBuilder: FormBuilder,
+    private roleService: RoleService,
+    private userService: UserService
+
+  ) {
+    this.roleService.getRolesBasic().subscribe({
+      error: (err) => {
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+        this.roles = [];
+      },
+      next: (res) => {
+        this.roles = res.content || [];
+      },
+    });
+    this.createUserForm = this.formBuilder.group({
+      name: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.minLength(4),
+          Validators.maxLength(45),
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/\s]+$/),
+        ])
+      ),
+      description: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.minLength(4),
+          Validators.maxLength(255),
+        ])
+      ),
+      username: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.pattern(/^[a-zA-Z0-9]+$/),
+          Validators.minLength(4),
+          Validators.maxLength(20),
+        ])
+      ),
+      password: this.formBuilder.control(
+        '',
+        Validators.compose([
+          Validators.required,
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[A-Z]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[0-9]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.pattern(
+            /^[a-zA-Z0-9\d@$!%*#?&]*[a-z]+[a-zA-Z0-9\d@$!%*#?&]*$/
+          ),
+          Validators.minLength(6),
+        ])
+      ),
+      role: this.formBuilder.control(''),
+    });
+  }
+
+  ngOnInit(): void {}
+
+  addRoleToList() {
+    const roleValue = this.createUserForm.get('role')?.value;
+    if (!roleValue) {
+      return;
+    }
+    const indexOfRole = this.roles.indexOf(roleValue);
+    this.roles.splice(indexOfRole, 1);
+    this.rolesList.push(roleValue);
+    this.createUserForm.get('role')?.setValue('');
+  }
+
+  removeRoleToList(role: BasicRole) {
+    const roleValue = role;
+    const indexOfRole = this.rolesList.indexOf(roleValue);
+    this.roles.unshift(role);
+    this.rolesList.splice(indexOfRole, 1);
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  createUser(createUserData: {
+    name: string;
+    username: string;
+    password: string;
+    role: string | undefined;
+  }) {
+    createUserData.role = undefined;
+    this.dialogRef.disableClose = true;
+    this.userService
+      .createUser({ ...createUserData, roles: this.rolesList })
+      .subscribe({
+        error: (err) => {
+          this.dialogRef.disableClose = false;
+          if (err.error) {
+            this.errorMessage = err.error.message;
+          } else {
+            this.errorMessage = 'Unknown Error';
+          }
+        },
+        next: () => {
+          this.dialogRef.close(true);
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/user/delete-user/delete-user.component.html
+++ b/src/app/dashboard/auth/user/delete-user/delete-user.component.html
@@ -1,0 +1,26 @@
+<h2 mat-dialog-title>Delete User {{ user.name }}</h2>
+<div mat-dialog-content>
+  <div class="error-display" *ngIf="errorMessage">
+    <h5>{{ errorMessage }}</h5>
+  </div>
+  <p>Are you sure?</p>
+</div>
+<div align="end" mat-dialog-actions>
+  <button
+    (click)="closeDialog()"
+    type="button"
+    color="warn"
+    mat-stroked-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Cancel</button
+  ><button
+    (click)="delete()"
+    type="button"
+    color="primary"
+    mat-flat-button
+    [disabled]="dialogRef.disableClose"
+  >
+    Delete
+  </button>
+</div>

--- a/src/app/dashboard/auth/user/delete-user/delete-user.component.scss
+++ b/src/app/dashboard/auth/user/delete-user/delete-user.component.scss
@@ -1,0 +1,10 @@
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}

--- a/src/app/dashboard/auth/user/delete-user/delete-user.component.spec.ts
+++ b/src/app/dashboard/auth/user/delete-user/delete-user.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DeleteUserComponent } from './delete-user.component';
+
+
+describe('DeleteUserComponent', () => {
+  let component: DeleteUserComponent;
+  let fixture: ComponentFixture<DeleteUserComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DeleteUserComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteUserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/user/delete-user/delete-user.component.ts
+++ b/src/app/dashboard/auth/user/delete-user/delete-user.component.ts
@@ -1,0 +1,41 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { User, UserService } from 'src/app/dashboard/services/user.service';
+
+@Component({
+  selector: 'lib-delete-user',
+  templateUrl: './delete-user.component.html',
+  styleUrls: ['./delete-user.component.scss'],
+})
+export class DeleteUserComponent implements OnInit {
+  errorMessage!: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<DeleteUserComponent>,
+    private userService: UserService,
+    @Inject(MAT_DIALOG_DATA) public user: User
+  ) {}
+
+  ngOnInit(): void {}
+
+  delete() {
+    this.dialogRef.disableClose = true;
+    this.userService.deleteUser(this.user.subjectId).subscribe({
+      error: (err) => {
+        this.dialogRef.disableClose = false;
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.dialogRef.close(true);
+      },
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/dashboard/auth/user/update-user/update-user.component.html
+++ b/src/app/dashboard/auth/user/update-user/update-user.component.html
@@ -1,0 +1,33 @@
+<h2 mat-dialog-title>Update User {{ user.name }}</h2>
+<form
+  [formGroup]="updateUserForm"
+  (ngSubmit)="updateUser(updateUserForm.value)"
+>
+  <div mat-dialog-content>
+    <div class="error-display" *ngIf="errorMessage">
+      <h5>{{ errorMessage }}</h5>
+    </div>
+    <mat-form-field class="forms-field" appearance="fill">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name" name="name" required />
+      <mat-hint>Put your name</mat-hint>
+    </mat-form-field>
+  </div>
+  <div align="end" mat-dialog-actions>
+    <button
+      (click)="closeDialog()"
+      type="button"
+      color="warn"
+      mat-stroked-button
+      [disabled]="dialogRef.disableClose"
+    >
+      Cancel</button
+    ><button
+      [disabled]="!updateUserForm.valid || dialogRef.disableClose"
+      color="primary"
+      mat-flat-button
+    >
+      Update
+    </button>
+  </div>
+</form>

--- a/src/app/dashboard/auth/user/update-user/update-user.component.scss
+++ b/src/app/dashboard/auth/user/update-user/update-user.component.scss
@@ -1,0 +1,40 @@
+.forms-field {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+.error-display {
+  margin: 1rem 0;
+  background-color: rgba(255, 171, 16, 0.596);
+  padding: 0.5rem;
+  border-radius: 0.25rem;
+  h5 {
+    margin: 0;
+    font-size: 16px;
+  }
+}
+
+.select-role {
+  display: grid;
+  grid-template-columns: auto 0.15fr;
+  gap: 0.5rem;
+  button {
+    height: 59.5px;
+  }
+  margin-bottom: 1rem;
+}
+
+.roles-list {
+  display: grid;
+  grid-template-columns: auto 0.1fr;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  .role-title {
+    border-radius: 0.25rem;
+    background-color: rgba(130, 199, 255, 0.267);
+    h3 {
+      margin: 0;
+    }
+    padding: 1rem;
+  }
+}

--- a/src/app/dashboard/auth/user/update-user/update-user.component.spec.ts
+++ b/src/app/dashboard/auth/user/update-user/update-user.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UpdateUserComponent } from './update-user.component';
+
+describe('UpdateUserComponent', () => {
+  let component: UpdateUserComponent;
+  let fixture: ComponentFixture<UpdateUserComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ UpdateUserComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UpdateUserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/user/update-user/update-user.component.ts
+++ b/src/app/dashboard/auth/user/update-user/update-user.component.ts
@@ -1,0 +1,56 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { User, UserService, UserUpdateBody } from 'src/app/dashboard/services/user.service';
+
+@Component({
+  selector: 'update-user',
+  templateUrl: './update-user.component.html',
+  styleUrls: ['./update-user.component.scss'],
+})
+export class UpdateUserComponent implements OnInit {
+  errorMessage!: string;
+  updateUserForm: FormGroup;
+
+  constructor(
+    private formBuilder: FormBuilder,
+    public dialogRef: MatDialogRef<UpdateUserComponent>,
+    private userService: UserService,
+    @Inject(MAT_DIALOG_DATA) public user: User
+  ) {
+    this.updateUserForm = this.formBuilder.group({
+      name: this.formBuilder.control(
+        user.name,
+        Validators.compose([
+          Validators.required,
+          Validators.minLength(4),
+          Validators.maxLength(45),
+          Validators.pattern(/^[a-zA-Z0-9_\.\-\/\s]+$/),
+        ])
+      ),
+    });
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+
+  updateUser(updateUserData: UserUpdateBody) {
+    this.dialogRef.disableClose = true;
+    this.userService.updateUser(this.user.subjectId, updateUserData).subscribe({
+      error: (err) => {
+        this.dialogRef.disableClose = false;
+        if (err.error) {
+          this.errorMessage = err.error.message;
+        } else {
+          this.errorMessage = 'Unknown Error';
+        }
+      },
+      next: () => {
+        this.dialogRef.close(true);
+      },
+    });
+  }
+
+  ngOnInit(): void {}
+}

--- a/src/app/dashboard/auth/user/user.component.html
+++ b/src/app/dashboard/auth/user/user.component.html
@@ -1,0 +1,90 @@
+<div class="user-container">
+    <div class="users-head">
+      <h1 class="user-title">Users</h1>
+      <span class="separator"></span>
+      <button (click)="openCreateUserDialog()" color="accent" mat-flat-button>
+        Add User
+      </button>
+    </div>
+    <div class="user-body">
+      <div class="container-table mat-elevation-z8">
+        <div class="loading-shade" *ngIf="isLoadingResults">
+          <mat-spinner *ngIf="isLoadingResults"></mat-spinner>
+        </div>
+        <div class="example-table-container">
+          <table
+            mat-table
+            [dataSource]="users"
+            class="user-table"
+            matSort
+            matSortActive="id"
+            matSortDisableClear
+            matSortDirection="asc"
+          >
+            <ng-container matColumnDef="id">
+              <th mat-sort-header mat-header-cell *matHeaderCellDef>id</th>
+              <td mat-cell *matCellDef="let row">{{ row.id }}</td>
+            </ng-container>
+  
+            <ng-container matColumnDef="name">
+              <th mat-header-cell *matHeaderCellDef>Name</th>
+              <td mat-cell *matCellDef="let row">{{ row.name }}</td>
+            </ng-container>
+  
+            <ng-container matColumnDef="username">
+              <th mat-header-cell *matHeaderCellDef>Username</th>
+              <td mat-cell *matCellDef="let row">{{ row.username }}</td>
+            </ng-container>
+  
+            <ng-container matColumnDef="roles">
+              <th mat-header-cell *matHeaderCellDef>Roles</th>
+              <td class="roles-column" mat-cell *matCellDef="let row">
+               <button (click)="openViewRolesDialog(row)" mat-stroked-button>
+                  View Roles
+                </button>
+                 <button
+                  [disabled]="row.username === 'admin'"
+                  (click)="openUpdateRolesDialog(row)"
+                  mat-stroked-button
+                >
+                  Update Roles
+                </button>
+              </td>
+            </ng-container>
+  
+            <ng-container matColumnDef="edit">
+              <th mat-header-cell *matHeaderCellDef></th>
+              <td class="actions-column" mat-cell *matCellDef="let row">
+               <button
+                  color="primary"
+                  [disabled]="row.username === 'admin'"
+                  mat-stroked-button
+                  (click)="openUpdateUserDialog(row)"
+                >
+                  Edit User
+                </button>
+                 <button
+                  color="warn"
+                  [disabled]="row.username === 'admin'"
+                  mat-stroked-button
+                  (click)="openDialogDeleteUser(row)"
+                >
+                  Delete User
+                </button>
+              </td>
+            </ng-container>
+  
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+          </table>
+        </div>
+  
+        <mat-paginator
+          [length]="resultsLength"
+          [pageSize]="20"
+          aria-label="Select page of GitHub search results"
+        ></mat-paginator>
+      </div>
+    </div>
+  </div>
+  

--- a/src/app/dashboard/auth/user/user.component.scss
+++ b/src/app/dashboard/auth/user/user.component.scss
@@ -1,0 +1,53 @@
+.user-container {
+    .users-head {
+      .separator {
+        flex: 1 0;
+      }
+  
+      .user-title {
+        margin: 0;
+        font-size: 32px;
+      }
+  
+      display: flex;
+  
+      margin-bottom: 2rem;
+    }
+  
+    table {
+      width: 100%;
+      th,
+      td {
+        width: 20%;
+      }
+      .roles-column {
+        button:last-child {
+          margin-left: 0.5rem;
+        }
+      }
+      .actions-column {
+        text-align: end;
+        button:last-child {
+          margin-left: 0.5rem;
+        }
+      }
+    }
+  
+    .container-table {
+      position: relative;
+    }
+  
+    .loading-shade {
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 56px;
+      right: 0;
+      background: rgba(0, 0, 0, 0.15);
+      z-index: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+  }
+  

--- a/src/app/dashboard/auth/user/user.component.ts
+++ b/src/app/dashboard/auth/user/user.component.ts
@@ -1,0 +1,166 @@
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatPaginator } from '@angular/material/paginator';
+import { CreateUserComponent } from './create-user/create-user.component';
+import { MatSort } from '@angular/material/sort';
+import { BehaviorSubject, catchError, first, map, merge, of, startWith, Subscription, switchMap } from 'rxjs';
+import { User, UserService } from '../../services/user.service';
+import { ViewUserRolesComponent } from './view-user-roles/view-user-roles.component';
+import { AddUserRolesComponent } from './add-user-roles/add-user-roles.component';
+import { UpdateUserComponent } from './update-user/update-user.component';
+import { DeleteUserComponent } from './delete-user/delete-user.component';
+
+
+@Component({
+    selector: 'app-user',
+    templateUrl: './user.component.html',
+    styleUrls: ['./user.component.scss']
+})
+
+export class UserComponent implements OnDestroy, AfterViewInit {
+    users!: User[];
+    errorMessage!: string | undefined;
+    displayedColumns: string[] = ['id', 'name', 'username', 'roles', 'edit'];
+
+    resultsLength = 0;
+    isLoadingResults = true;
+
+    reload = new BehaviorSubject<number>(0);
+    pageSize = 20;
+
+
+    userDataSubscription!: Subscription;
+    @ViewChild(MatPaginator) paginator!: MatPaginator;
+    @ViewChild(MatSort) sort!: MatSort;
+
+    constructor(
+        private userService: UserService,
+        public dialog: MatDialog
+    ) { }
+
+    ngOnDestroy(): void {
+        this.userDataSubscription?.unsubscribe();
+        this.sort.sortChange.complete();
+    }
+
+    ngAfterViewInit(): void {
+        this.sort.sortChange.subscribe(() => (this.paginator.pageIndex = 0));
+        this.userDataSubscription = merge(
+            this.sort.sortChange,
+            this.paginator.page,
+            this.reload
+        )
+            .pipe(
+                startWith({}),
+                switchMap(() => {
+                    this.errorMessage = undefined;
+                    this.isLoadingResults = true;
+                    return this.userService!.getUsers(
+                        this.paginator.pageIndex,
+                        this.sort.direction
+                    ).pipe(
+                        catchError((err) => {
+                            if (err.error) {
+                                this.errorMessage = err.error.message;
+                            } else {
+                                this.errorMessage = 'Unknown Error';
+                            }
+                            return of(null);
+                        })
+                    );
+                }),
+                map((data) => {
+                    this.isLoadingResults = false;
+                    if (data === null) {
+                        return [];
+                    }
+                    this.resultsLength = data.content?.totalItems || 0;
+                    return data.content?.items || [];
+                })
+            )
+            .subscribe((data) => {
+                this.users = data;
+            });
+    }
+
+  openCreateUserDialog() {
+      const createUserDialogRef = this.dialog.open(CreateUserComponent, {
+        width: '600px',
+        maxHeight: '70vh',
+      });
+      createUserDialogRef
+        .afterClosed()
+        .pipe(first())
+        .subscribe({
+          next: (res) => {
+            if (res) {
+              this.reload.next(this.reload.value + 1);
+            }
+          },
+      });
+  }
+
+  openViewRolesDialog(user: User) {
+      this.dialog.open(ViewUserRolesComponent, {
+        width: '600px',
+        maxHeight: '70vh',
+        data: user,
+      });
+  }
+
+  openUpdateRolesDialog(user: User) {
+      const updateRolesDialogRef = this.dialog.open(AddUserRolesComponent, {
+        width: '600px',
+        maxHeight: '70vh',
+        data: user,
+      });
+  
+      updateRolesDialogRef
+        .afterClosed()
+        .pipe(first())
+        .subscribe({
+          next: (res) => {
+            if (res) {
+              this.reload.next(this.reload.value + 1);
+            }
+          },
+      });
+  }
+
+  openUpdateUserDialog(user: User) {
+      const updateUserDialogRef = this.dialog.open(UpdateUserComponent, {
+        width: '600px',
+        maxHeight: '70vh',
+        data: user,
+      });
+  
+      updateUserDialogRef
+        .afterClosed()
+        .pipe(first())
+        .subscribe({
+          next: (res) => {
+            if (res) {
+              this.reload.next(this.reload.value + 1);
+            }
+          },
+      });
+  }
+  openDialogDeleteUser(user: User) {
+    const updateRolesDialogRef = this.dialog.open(DeleteUserComponent, {
+      width: '600px',
+      maxHeight: '70vh',
+      data: user,
+    });
+
+    updateRolesDialogRef
+      .afterClosed()
+      .pipe(first())
+      .subscribe({
+        next: (res) => {
+          if (res) {
+            this.reload.next(this.reload.value + 1);
+          }
+        },
+      });
+  }
+}

--- a/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.html
+++ b/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.html
@@ -1,0 +1,35 @@
+<h2 class="primary-color" mat-dialog-title>{{ userTitle }}</h2>
+<div mat-dialog-content>
+  <div class="accordion-container">
+    <mat-accordion>
+      <mat-expansion-panel *ngFor="let role of user.roles">
+        <mat-expansion-panel-header>
+          <mat-panel-title> {{ role.identifier }} </mat-panel-title>
+        </mat-expansion-panel-header>
+        <h4>Grouped by application resource</h4>
+        <mat-list>
+          <div *ngFor="let option of role.resources">
+            <div mat-subheader>{{ option.applicationResourceName }}</div>
+            <mat-list-item *ngFor="let allowed of option.allowed">
+              <mat-icon mat-list-icon>vpn_key</mat-icon>
+              <div mat-line>
+                {{ option.applicationResourceName }}:{{ allowed }}
+              </div>
+            </mat-list-item>
+            <mat-divider></mat-divider>
+          </div>
+        </mat-list>
+      </mat-expansion-panel>
+    </mat-accordion>
+  </div>
+</div>
+<div align="end" mat-dialog-actions>
+  <button
+    (click)="closeDialog()"
+    type="button"
+    color="primary"
+    mat-stroked-button
+  >
+    Ok
+  </button>
+</div>

--- a/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.scss
+++ b/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.scss
@@ -1,0 +1,37 @@
+.header {
+  h1 {
+    margin: 0;
+    font-size: 32px;
+  }
+
+  h4 {
+    margin: 0;
+    color: gray;
+  }
+
+  display: flex;
+
+  align-items: baseline;
+  gap: 0.5rem;
+
+  flex-wrap: wrap;
+}
+
+section {
+  display: grid;
+  .roles-list {
+    color: black;
+  }
+
+  .actions {
+    margin-top: 2rem;
+  }
+}
+
+.profile-container ::ng-deep .mat-list-base {
+  .mat-list-item {
+    .mat-list-item-content {
+      color: black;
+    }
+  }
+}

--- a/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.spec.ts
+++ b/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ViewUserRolesComponent } from './view-user-roles.component';
+
+describe('ViewUserRolesComponent', () => {
+  let component: ViewUserRolesComponent;
+  let fixture: ComponentFixture<ViewUserRolesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ViewUserRolesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ViewUserRolesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.ts
+++ b/src/app/dashboard/auth/user/view-user-roles/view-user-roles.component.ts
@@ -1,0 +1,24 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { User } from 'src/app/dashboard/services/user.service';
+
+@Component({
+  selector: 'lib-view-user-roles',
+  templateUrl: './view-user-roles.component.html',
+  styleUrls: ['./view-user-roles.component.scss'],
+})
+export class ViewUserRolesComponent implements OnInit {
+  userTitle: string;
+
+  constructor(
+    public dialogRef: MatDialogRef<ViewUserRolesComponent>,
+    @Inject(MAT_DIALOG_DATA) public user: User
+  ) {
+    this.userTitle = `${user.name} roles`;
+  }
+
+  closeDialog() {
+    this.dialogRef.close();
+  }
+  ngOnInit(): void {}
+}

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -10,7 +10,7 @@ import { UserComponent } from './access/user/user.component';
 import { UserComponent as AuthUserComponent } from './auth/user/user.component';
 import { RoleComponent as AuthRoleComponent } from './auth/role/role.component';
 import { ApplicationResourceComponent as AuthApplicationResourceComponent } from './auth/application-resource/application-resource.component';
-
+import { ClientComponent as AuthClientComponent} from "./auth/client/client.component";
 
 
 
@@ -38,7 +38,8 @@ const routes: Routes = [
       },
       {
         path: 'auth/clients',
-        component: ClientComponent,
+        //component: ClientComponent,
+        component: AuthClientComponent,
         canActivate: [AdminGuard],
         canLoad: [AdminGuard],
       },

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -8,6 +8,8 @@ import { RoleComponent } from './access/role/role.component';
 import { UserProfileComponent } from './access/user-profile/user-profile.component';
 import { UserComponent } from './access/user/user.component';
 import { UserComponent as AuthUserComponent } from './auth/user/user.component';
+import { RoleComponent as AuthRoleComponent } from './auth/role/role.component';
+
 
 
 import { DashboardComponent } from './dashboard.component';
@@ -40,7 +42,8 @@ const routes: Routes = [
       },
       {
         path: 'auth/roles',
-        component: RoleComponent,
+        // component: RoleComponent,
+        component: AuthRoleComponent,
         canActivate: [AdminGuard],
         canLoad: [AdminGuard],
       },

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -2,11 +2,11 @@ import { EditActionComponent } from './action/edit-action/edit-action.component'
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { AdminGuard } from '../guards/admin.guard';
-import { ApplicationResourceComponent } from './access/application-resource/application-resource.component';
+/* import { ApplicationResourceComponent } from './access/application-resource/application-resource.component';
 import { ClientComponent } from './access/client/client.component';
 import { RoleComponent } from './access/role/role.component';
 import { UserProfileComponent } from './access/user-profile/user-profile.component';
-import { UserComponent } from './access/user/user.component';
+import { UserComponent } from './access/user/user.component'; */
 import { UserComponent as AuthUserComponent } from './auth/user/user.component';
 import { RoleComponent as AuthRoleComponent } from './auth/role/role.component';
 import { ApplicationResourceComponent as AuthApplicationResourceComponent } from './auth/application-resource/application-resource.component';

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -7,6 +7,8 @@ import { ClientComponent } from './access/client/client.component';
 import { RoleComponent } from './access/role/role.component';
 import { UserProfileComponent } from './access/user-profile/user-profile.component';
 import { UserComponent } from './access/user/user.component';
+import { UserComponent as AuthUserComponent } from './auth/user/user.component';
+
 
 import { DashboardComponent } from './dashboard.component';
 import routesList from './routes';
@@ -25,7 +27,8 @@ const routes: Routes = [
       },
       {
         path: 'auth/users',
-        component: UserComponent,
+        // component: UserComponent,
+        component: AuthUserComponent,
         canActivate: [AdminGuard],
         canLoad: [AdminGuard],
       },

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -11,6 +11,7 @@ import { UserComponent as AuthUserComponent } from './auth/user/user.component';
 import { RoleComponent as AuthRoleComponent } from './auth/role/role.component';
 import { ApplicationResourceComponent as AuthApplicationResourceComponent } from './auth/application-resource/application-resource.component';
 import { ClientComponent as AuthClientComponent} from "./auth/client/client.component";
+import { UserProfileComponent as AuthUserProfileComponent } from "./auth/user-profile/user-profile.component"
 
 
 
@@ -57,7 +58,12 @@ const routes: Routes = [
         canActivate: [AdminGuard],
         canLoad: [AdminGuard],
       },
-      { path: 'profile', component: UserProfileComponent },
+      { 
+        path: 'profile', 
+        // component: UserProfileComponent
+        component: AuthUserProfileComponent 
+
+      },
       { path: '', redirectTo: 'profile', pathMatch: 'full' },
     ],
   },

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -9,6 +9,8 @@ import { UserProfileComponent } from './access/user-profile/user-profile.compone
 import { UserComponent } from './access/user/user.component';
 import { UserComponent as AuthUserComponent } from './auth/user/user.component';
 import { RoleComponent as AuthRoleComponent } from './auth/role/role.component';
+import { ApplicationResourceComponent as AuthApplicationResourceComponent } from './auth/application-resource/application-resource.component';
+
 
 
 
@@ -49,7 +51,8 @@ const routes: Routes = [
       },
       {
         path: 'auth/resource',
-        component: ApplicationResourceComponent,
+        //component: ApplicationResourceComponent,
+        component: AuthApplicationResourceComponent,
         canActivate: [AdminGuard],
         canLoad: [AdminGuard],
       },

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -59,6 +59,11 @@ import { DeleteUserComponent } from './auth/user/delete-user/delete-user.compone
 import { CreateRoleComponent } from './auth/role/create-role/create-role.component';
 import { DeleteRoleComponent } from './auth/role/delete-role/delete-role.component';
 import { OptionsComponent } from './auth/role/options/options.component';
+import { DeleteApplicationResourceComponent } from './auth/application-resource/delete-application-resource/delete-application-resource.component';
+import { CreateApplicationResourceComponent } from './auth/application-resource/create-application-resource/create-application-resource.component';
+import { ApplicationOptionsComponent } from './auth/application-resource/application-options/application-options.component';
+import { ApplicationResourceComponent as AuthApplicationResourceComponent } from './auth/application-resource/application-resource.component';
+
 
 @NgModule({
   declarations: [
@@ -97,7 +102,12 @@ import { OptionsComponent } from './auth/role/options/options.component';
     AuthRoleComponent,
     CreateRoleComponent,
     DeleteRoleComponent,
-    OptionsComponent
+    OptionsComponent,
+    DeleteApplicationResourceComponent,
+    ApplicationResourceComponent,
+    CreateApplicationResourceComponent,
+    ApplicationOptionsComponent,
+    AuthApplicationResourceComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -12,12 +12,12 @@ import { DashboardRoutingModule } from './dashboard-routing.module';
 import { DashBoardMaterials } from './material/material.module';
 import { TablesComponent } from './tables/tables.component';
 import { EventsLogComponent } from './events-log/events-log.component';
-import { UserComponent } from './access/user/user.component';
+/* import { UserComponent } from './access/user/user.component';
 import { ClientComponent } from './access/client/client.component';
 import { RoleComponent } from './access/role/role.component';
 import { ApplicationResourceComponent } from './access/application-resource/application-resource.component';
-import { UserProfileComponent } from './access/user-profile/user-profile.component';
-import { NodebootOauth2StarterModule } from 'nodeboot-oauth2-starter-ui';
+import { UserProfileComponent } from './access/user-profile/user-profile.component'; */
+// import { NodebootOauth2StarterModule } from 'nodeboot-oauth2-starter-ui';
 import { SystemComponent } from './system/system.component';
 import { EventComponent } from './event/event.component';
 import { ActionComponent } from './action/action.component';
@@ -85,11 +85,11 @@ import { ChangePasswordComponent } from './auth/user-profile/change-password/cha
     DashboardComponent,
     TablesComponent,
     EventsLogComponent,
-    UserComponent,
+    /* UserComponent,
     ClientComponent,
     RoleComponent,
     ApplicationResourceComponent,
-    UserProfileComponent,
+    UserProfileComponent, */
     SystemComponent,
     EventComponent,
     ActionComponent,
@@ -119,7 +119,7 @@ import { ChangePasswordComponent } from './auth/user-profile/change-password/cha
     DeleteRoleComponent,
     OptionsComponent,
     DeleteApplicationResourceComponent,
-    ApplicationResourceComponent,
+    // ApplicationResourceComponent,
     CreateApplicationResourceComponent,
     ApplicationOptionsComponent,
     AuthApplicationResourceComponent,
@@ -133,7 +133,7 @@ import { ChangePasswordComponent } from './auth/user-profile/change-password/cha
     DeleteClientComponent,
     CreateClientComponent,
     AddClientRolesComponent,
-    UserProfileComponent,
+    // UserProfileComponent,
     AuthUserProfileComponent,
     ChangePasswordComponent,
     ChangePasswordComponent
@@ -142,7 +142,7 @@ import { ChangePasswordComponent } from './auth/user-profile/change-password/cha
     CommonModule,
     DashboardRoutingModule,
     DashBoardMaterials,
-    NodebootOauth2StarterModule,
+    // NodebootOauth2StarterModule,
     ReactiveFormsModule,
     FormsModule,
     MatMomentDateModule,

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -32,6 +32,8 @@ import { DeleteActionComponent } from './action/delete-action/delete-action.comp
 import { DeleteContractComponent } from './contract/delete-contract/delete-contract.component';
 import { EditContractComponent } from './contract/edit-contract/edit-contract.component';
 import { UserComponent as AuthUserComponent } from './auth/user/user.component';
+import { RoleComponent as AuthRoleComponent } from './auth/role/role.component';
+
 
 import {
   DateAdapter,
@@ -54,6 +56,9 @@ import { ViewUserRolesComponent } from './auth/user/view-user-roles/view-user-ro
 import { AddUserRolesComponent } from './auth/user/add-user-roles/add-user-roles.component';
 import { UpdateUserComponent } from './auth/user/update-user/update-user.component';
 import { DeleteUserComponent } from './auth/user/delete-user/delete-user.component';
+import { CreateRoleComponent } from './auth/role/create-role/create-role.component';
+import { DeleteRoleComponent } from './auth/role/delete-role/delete-role.component';
+import { OptionsComponent } from './auth/role/options/options.component';
 
 @NgModule({
   declarations: [
@@ -89,6 +94,10 @@ import { DeleteUserComponent } from './auth/user/delete-user/delete-user.compone
     AddUserRolesComponent,
     UpdateUserComponent,
     DeleteUserComponent,
+    AuthRoleComponent,
+    CreateRoleComponent,
+    DeleteRoleComponent,
+    OptionsComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -73,8 +73,11 @@ import { DeleteClientComponent } from './auth/client/delete-client/delete-client
 import { CreateClientComponent } from './auth/client/create-client/create-client.component';
 import { AddClientRolesComponent } from './auth/client/add-client-roles/add-client-roles.component';
 import { ShowSecretComponent } from './auth/client/show-secret/show-secret.component';
+import { UserProfileComponent as AuthUserProfileComponent } from './auth/user-profile/user-profile.component';
+
 import { ClipboardModule } from 'ngx-clipboard';
 import { HttpClientModule } from '@angular/common/http';
+import { ChangePasswordComponent } from './auth/user-profile/change-password/change-password.component';
 
 
 @NgModule({
@@ -129,7 +132,11 @@ import { HttpClientModule } from '@angular/common/http';
     RevokeTokenComponent,
     DeleteClientComponent,
     CreateClientComponent,
-    AddClientRolesComponent
+    AddClientRolesComponent,
+    UserProfileComponent,
+    AuthUserProfileComponent,
+    ChangePasswordComponent,
+    ChangePasswordComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -63,6 +63,18 @@ import { DeleteApplicationResourceComponent } from './auth/application-resource/
 import { CreateApplicationResourceComponent } from './auth/application-resource/create-application-resource/create-application-resource.component';
 import { ApplicationOptionsComponent } from './auth/application-resource/application-options/application-options.component';
 import { ApplicationResourceComponent as AuthApplicationResourceComponent } from './auth/application-resource/application-resource.component';
+import { ClientComponent as AuthClientComponent} from "./auth/client/client.component";
+import { ViewClientRolesComponent } from './auth/client/view-client-roles/view-client-roles.component';
+import { UpdateClientComponent } from './auth/client/update-client/update-client.component';
+import { ShowNewTokenComponent } from './auth/client/show-new-token/show-new-token.component';
+import { ShowTokenComponent } from './auth/client/show-token/show-token.component';
+import { RevokeTokenComponent } from './auth/client/revoke-token/revoke-token.component';
+import { DeleteClientComponent } from './auth/client/delete-client/delete-client.component';
+import { CreateClientComponent } from './auth/client/create-client/create-client.component';
+import { AddClientRolesComponent } from './auth/client/add-client-roles/add-client-roles.component';
+import { ShowSecretComponent } from './auth/client/show-secret/show-secret.component';
+import { ClipboardModule } from 'ngx-clipboard';
+import { HttpClientModule } from '@angular/common/http';
 
 
 @NgModule({
@@ -107,7 +119,17 @@ import { ApplicationResourceComponent as AuthApplicationResourceComponent } from
     ApplicationResourceComponent,
     CreateApplicationResourceComponent,
     ApplicationOptionsComponent,
-    AuthApplicationResourceComponent
+    AuthApplicationResourceComponent,
+    AuthClientComponent,
+    ViewClientRolesComponent,
+    UpdateClientComponent,
+    ShowNewTokenComponent,
+    ShowSecretComponent,
+    ShowTokenComponent,
+    RevokeTokenComponent,
+    DeleteClientComponent,
+    CreateClientComponent,
+    AddClientRolesComponent
   ],
   imports: [
     CommonModule,
@@ -118,6 +140,8 @@ import { ApplicationResourceComponent as AuthApplicationResourceComponent } from
     FormsModule,
     MatMomentDateModule,
     MatDatepickerModule,
+    ClipboardModule,
+    HttpClientModule
   ],
   providers: [
     { provide: LOCALE_ID, useValue: 'es-PE' },

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -31,6 +31,8 @@ import { EditActionComponent } from './action/edit-action/edit-action.component'
 import { DeleteActionComponent } from './action/delete-action/delete-action.component';
 import { DeleteContractComponent } from './contract/delete-contract/delete-contract.component';
 import { EditContractComponent } from './contract/edit-contract/edit-contract.component';
+import { UserComponent as AuthUserComponent } from './auth/user/user.component';
+
 import {
   DateAdapter,
   MAT_DATE_FORMATS,
@@ -47,6 +49,11 @@ import { EventExecutionDetailsComponent } from './events-log/event-execution-det
 import { EventContractsComponent } from './events-log/event-contracts/event-contracts.component';
 import { ContractExecutionDetailComponent } from './events-log/contract-execution-detail/contract-execution-detail.component';
 import { ViewContractsComponent } from './event/view-contracts/view-contracts.component';
+import { CreateUserComponent } from './auth/user/create-user/create-user.component';
+import { ViewUserRolesComponent } from './auth/user/view-user-roles/view-user-roles.component';
+import { AddUserRolesComponent } from './auth/user/add-user-roles/add-user-roles.component';
+import { UpdateUserComponent } from './auth/user/update-user/update-user.component';
+import { DeleteUserComponent } from './auth/user/delete-user/delete-user.component';
 
 @NgModule({
   declarations: [
@@ -76,6 +83,12 @@ import { ViewContractsComponent } from './event/view-contracts/view-contracts.co
     EventContractsComponent,
     ContractExecutionDetailComponent,
     ViewContractsComponent,
+    AuthUserComponent,
+    CreateUserComponent,
+    ViewUserRolesComponent,
+    AddUserRolesComponent,
+    UpdateUserComponent,
+    DeleteUserComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/dashboard/events-log/event-contracts/event-contracts.component.ts
+++ b/src/app/dashboard/events-log/event-contracts/event-contracts.component.ts
@@ -42,7 +42,6 @@ export class EventContractsComponent implements OnInit {
         )
         .subscribe({
           next: (res) => {
-            console.log(res.content)
             this.receivedEvent = res.content.receivedEvent;
             this.receivedEventDetails = res.content.executedEventContracts;
           },
@@ -71,7 +70,6 @@ export class EventContractsComponent implements OnInit {
   }
 
   retrySendEventContract(contractId: number, contractDetailId: number, receivedEventId:  number) {
-    console.log(receivedEventId)
     this.eventService.handleEventContract(
       this.receivedEvent.received_request.query["event-identifier"], 
       this.receivedEvent.received_request.query["access-key"],

--- a/src/app/dashboard/material/material.module.ts
+++ b/src/app/dashboard/material/material.module.ts
@@ -18,6 +18,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatDialogModule } from '@angular/material/dialog';
 
 
 @NgModule({
@@ -40,7 +41,8 @@ import { MatExpansionModule } from '@angular/material/expansion';
     MatProgressSpinnerModule,
     MatCardModule,
     MatAutocompleteModule,
-    MatExpansionModule
+    MatExpansionModule,
+    MatDialogModule
   ],
 })
 export class DashBoardMaterials {}

--- a/src/app/dashboard/material/material.module.ts
+++ b/src/app/dashboard/material/material.module.ts
@@ -17,6 +17,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatCardModule } from '@angular/material/card';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
+import { MatExpansionModule } from '@angular/material/expansion';
 
 
 @NgModule({
@@ -38,7 +39,8 @@ import { MatAutocompleteModule } from "@angular/material/autocomplete";
     MatPaginatorModule,
     MatProgressSpinnerModule,
     MatCardModule,
-    MatAutocompleteModule
+    MatAutocompleteModule,
+    MatExpansionModule
   ],
 })
 export class DashBoardMaterials {}

--- a/src/app/dashboard/material/material.module.ts
+++ b/src/app/dashboard/material/material.module.ts
@@ -19,6 +19,9 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatAutocompleteModule } from "@angular/material/autocomplete";
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
 
 
 @NgModule({
@@ -42,7 +45,9 @@ import { MatDialogModule } from '@angular/material/dialog';
     MatCardModule,
     MatAutocompleteModule,
     MatExpansionModule,
-    MatDialogModule
+    MatDialogModule,
+    MatCheckboxModule,
+    MatTooltipModule
   ],
 })
 export class DashBoardMaterials {}

--- a/src/app/dashboard/services/application.service.ts
+++ b/src/app/dashboard/services/application.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { first, Observable } from "rxjs";
+import { environment } from "src/environments/environment";
+import { BasicRole } from "./role.service";
+
+@Injectable({
+    providedIn: 'root',
+})
+
+export class ApplicationService {
+  httpRoute = environment.api + '/auth/application';
+
+  constructor(private http: HttpClient) {}
+
+
+  getApplications(): Observable<ApplicationResult> {
+    return this.http.get<ApplicationResult>(this.httpRoute);
+  }
+}
+
+interface ApplicationResult {
+    message: string;
+    code: number;
+    content?: Application[];
+  }
+  
+  export interface Application {
+    id: number;
+    identifier: string;
+  }
+  

--- a/src/app/dashboard/services/client.service.ts
+++ b/src/app/dashboard/services/client.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { first, Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
+import { BasicRole, Role } from './role.service';
 
 @Injectable({
   providedIn: 'root',
@@ -11,11 +12,96 @@ export class ClientService {
 
   constructor(private http: HttpClient) {}
 
-  getClients(pageIndex: number): Observable<ClientPaginationResult> {
+  getClients(
+    pageIndex: number,
+    order?: string
+  ): Observable<ClientPaginationResult> {
     return this.http
       .get<ClientPaginationResult>(
-        this.httpRoute + `?pageIndex=${pageIndex}&&itemsPerPage=100&&order=desc`
+        this.httpRoute +
+          `?pageIndex=${pageIndex}&&itemsPerPage=20&&order=${order}`
       )
+      .pipe(first());
+  }
+
+  getSecret(clientId: number): Observable<SecretTokenResponse> {
+    return this.http
+      .get<SecretTokenResponse>(this.httpRoute + `/${clientId}/secret`)
+      .pipe(first());
+  }
+
+  generateLongLiveToken(
+    clientId: number,
+    identifier: string
+  ): Observable<LongLiveTokenResponse> {
+    return this.http
+      .put<LongLiveTokenResponse>(
+        this.httpRoute + `/${clientId}/long-live`,
+        {
+          identifier,
+        }
+      )
+      .pipe(first());
+  }
+
+  removeLongLiveToken(
+    clientId: number,
+    identifier: string
+  ): Observable<BasicResponse> {
+    return this.http
+      .put<BasicResponse>(
+        this.httpRoute + `/${clientId}/long-live?remove_long_live=true`,
+        {
+          identifier,
+        }
+      )
+      .pipe(first());
+  }
+
+  modifyRevokeStatus(clientId: number, revoke: boolean) {
+    return this.http
+      .put<BasicResponse>(this.httpRoute + `/${clientId}/revoke`, {
+        revoke,
+      })
+      .pipe(first());
+  }
+
+  updateClient(subjectId: number, updateBody: ClientUpdateBody) {
+    return this.http
+      .put(`${this.httpRoute}/${subjectId}`, updateBody)
+      .pipe(first());
+  }
+
+  deleteClient(subjectId: number) {
+    return this.http.delete(`${this.httpRoute}/${subjectId}`).pipe(first());
+  }
+
+  createClient(
+    createClientData: {
+      name: string;
+      identifier: string;
+      roles: BasicRole[];
+    },
+    longLive: boolean
+  ): Observable<ClientCreateResult> {
+    return this.http
+      .post<ClientCreateResult>(
+        this.httpRoute + `?longLive=${longLive}`,
+        createClientData
+      )
+      .pipe(first());
+  }
+
+  updateClientRoles(
+    clientId: number,
+    roles: BasicRole[],
+    originalRolesList: BasicRole[]
+  ) {
+    return this.http
+      .put(`${this.httpRoute}/${clientId}/role`, {
+        roles,
+        originalRolesList,
+      })
       .pipe(first());
   }
 }
@@ -24,6 +110,11 @@ interface ClientPaginationResult {
   message: string;
   code: number;
   content?: ClientPaginationContent;
+}
+
+interface BasicResponse {
+  message: string;
+  code: number;
 }
 
 interface ClientPaginationContent {
@@ -44,17 +135,36 @@ export interface Client {
   revoked?: boolean;
   roles: Role[];
 }
-
-export interface Role {
-  id: number;
-  identifier: string;
-  resources: Resource[];
+export interface ClientCreateContent {
+  clientSecret: string;
+  clientId: string;
+  access_token: string;
 }
 
-export interface Resource {
-  id: number;
-  applicationResourceName: string;
-  allowed: Permission[];
+interface SecretTokenResponse {
+  message: string;
+  code: number;
+  content: {
+    clientSecret: string;
+  };
+}
+
+interface LongLiveTokenResponse {
+  message: string;
+  code: number;
+  content: {
+    access_token: string;
+  };
+}
+
+export interface ClientUpdateBody {
+  name: string;
+}
+
+interface ClientCreateResult {
+  message: string;
+  code: number;
+  content?: ClientCreateContent;
 }
 
 export interface Permission {

--- a/src/app/dashboard/services/resource.service.ts
+++ b/src/app/dashboard/services/resource.service.ts
@@ -29,20 +29,6 @@ export class ResourceService {
             )
             .pipe(first());
     }
-
-    updateRoleOptions(
-        roleId: number,
-        newAllowedObject: Record<string, Option[]>,
-        originalAllowedObject: Record<string, Option[]>
-      ) {
-        return this.http
-          .put(this.httpRoute + `/${roleId}/permission`, {
-            newAllowedObject: newAllowedObject,
-            originalAllowedObject: originalAllowedObject,
-          })
-          .pipe(first());
-      }
-
 }
 
 interface ResourcePaginationResult {

--- a/src/app/dashboard/services/resource.service.ts
+++ b/src/app/dashboard/services/resource.service.ts
@@ -1,0 +1,75 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { first, Observable } from "rxjs";
+import { environment } from "src/environments/environment";
+
+@Injectable({
+    providedIn: 'root',
+})
+
+export class ResourceService {
+    httpRoute = environment.api + '/auth/resource';
+
+    constructor(private http: HttpClient) { }
+
+    getResourcesBasic(): Observable<OptionResult> {
+        return this.http
+            .get<OptionResult>(this.httpRoute + `?basic=true`)
+            .pipe(first());
+    }
+
+    getResources(
+        pageIndex: number,
+        order: string
+    ): Observable<ResourcePaginationResult> {
+        return this.http
+            .get<ResourcePaginationResult>(
+                this.httpRoute +
+                `?pageIndex=${pageIndex}&&itemsPerPage=20&&order=${order}`
+            )
+            .pipe(first());
+    }
+
+    updateRoleOptions(
+        roleId: number,
+        newAllowedObject: Record<string, Option[]>,
+        originalAllowedObject: Record<string, Option[]>
+      ) {
+        return this.http
+          .put(this.httpRoute + `/${roleId}/permission`, {
+            newAllowedObject: newAllowedObject,
+            originalAllowedObject: originalAllowedObject,
+          })
+          .pipe(first());
+      }
+
+}
+
+interface ResourcePaginationResult {
+    message: string;
+    code: number;
+    content?: ResourcePaginationContent;
+}
+
+interface OptionResult {
+    message: string;
+    code: number;
+    content?: Resource[];
+}
+export interface Option {
+    allowed: string;
+    id: number;
+}
+export interface Resource {
+    id: number;
+    applicationResourceName: string;
+    allowed: Option[];
+}
+
+interface ResourcePaginationContent {
+    items: Resource[];
+    pageIndex: number;
+    itemsPerPage: number;
+    totalItems: number;
+    totalPages: number;
+}

--- a/src/app/dashboard/services/resource.service.ts
+++ b/src/app/dashboard/services/resource.service.ts
@@ -29,6 +29,30 @@ export class ResourceService {
             )
             .pipe(first());
     }
+
+    createResource(resourceIdentifier: string, applications_id: number) {
+        return this.http.post(this.httpRoute, {
+            resourceIdentifier,
+            applications_id,
+        });
+    }
+
+    updateResourceOptions(
+        resourceId: number,
+        newResourceOptions: Option[],
+        originalResourceOptions: Option[]
+    ) {
+        return this.http
+            .put(this.httpRoute + `/${resourceId}/permission`, {
+                newResourcePermissions: newResourceOptions,
+                originalResourcePermissions: originalResourceOptions,
+            })
+            .pipe(first());
+    }
+
+    deleteResource(resourceId: number) {
+        return this.http.delete(this.httpRoute + `/${resourceId}`);
+    }
 }
 
 interface ResourcePaginationResult {

--- a/src/app/dashboard/services/role.service.ts
+++ b/src/app/dashboard/services/role.service.ts
@@ -1,0 +1,31 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { first, Observable } from "rxjs";
+import { environment } from "src/environments/environment";
+
+@Injectable({
+    providedIn: 'root',
+})
+
+export class RoleService {
+    httpRoute = environment.api + '/auth/role';
+
+    constructor(private http: HttpClient) {}
+
+    getRolesBasic(): Observable<RoleResult> {
+        return this.http
+          .get<RoleResult>(this.httpRoute + '?basic=true')
+          .pipe(first());
+      }
+}
+
+export interface BasicRole {
+    id: number;
+    identifier: string;
+}
+
+interface RoleResult {
+    message: string;
+    code: number;
+    content?: BasicRole[];
+}

--- a/src/app/dashboard/services/role.service.ts
+++ b/src/app/dashboard/services/role.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { first, Observable } from "rxjs";
 import { environment } from "src/environments/environment";
+import { Option, Resource } from "./resource.service";
 
 @Injectable({
     providedIn: 'root',
@@ -10,13 +11,32 @@ import { environment } from "src/environments/environment";
 export class RoleService {
     httpRoute = environment.api + '/auth/role';
 
-    constructor(private http: HttpClient) {}
+    constructor(private http: HttpClient) { }
 
+    getRoles(pageIndex: number, order: string): Observable<RolePaginationResult> {
+        return this.http
+            .get<RolePaginationResult>(
+                this.httpRoute +
+                `?pageIndex=${pageIndex}&&itemsPerPage=20&&order=${order}`
+            )
+            .pipe(first());
+    }
     getRolesBasic(): Observable<RoleResult> {
         return this.http
-          .get<RoleResult>(this.httpRoute + '?basic=true')
-          .pipe(first());
-      }
+            .get<RoleResult>(this.httpRoute + '?basic=true')
+            .pipe(first());
+    }
+
+
+    createRole(identifier: string, allowedObject: Record<string, Option[]>) {
+        return this.http
+            .post(this.httpRoute, { identifier, allowedObject })
+            .pipe(first());
+    }
+
+    deleteRole(roleId: number) {
+        return this.http.delete(this.httpRoute + `/${roleId}`).pipe(first());
+    }
 }
 
 export interface BasicRole {
@@ -28,4 +48,24 @@ interface RoleResult {
     message: string;
     code: number;
     content?: BasicRole[];
+}
+
+export interface Role {
+    id: number;
+    identifier: string;
+    resources: Resource[];
+}
+
+interface RolePaginationResult {
+    message: string;
+    code: number;
+    content?: RolePaginationContent;
+}
+
+interface RolePaginationContent {
+    items: Role[];
+    pageIndex: number;
+    itemsPerPage: number;
+    totalItems: number;
+    totalPages: number;
 }

--- a/src/app/dashboard/services/role.service.ts
+++ b/src/app/dashboard/services/role.service.ts
@@ -37,6 +37,19 @@ export class RoleService {
     deleteRole(roleId: number) {
         return this.http.delete(this.httpRoute + `/${roleId}`).pipe(first());
     }
+
+    updateRoleOptions(
+        roleId: number,
+        newAllowedObject: Record<string, Option[]>,
+        originalAllowedObject: Record<string, Option[]>
+      ) {
+        return this.http
+          .put(this.httpRoute + `/${roleId}/permission`, {
+            newAllowedObject: newAllowedObject,
+            originalAllowedObject: originalAllowedObject,
+          })
+          .pipe(first());
+      }
 }
 
 export interface BasicRole {

--- a/src/app/dashboard/services/user.service.ts
+++ b/src/app/dashboard/services/user.service.ts
@@ -1,0 +1,91 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { first, Observable } from "rxjs";
+import { environment } from "src/environments/environment";
+import { BasicRole } from "./role.service";
+
+@Injectable({
+    providedIn: 'root',
+})
+
+export class UserService {
+  httpRoute = environment.api + '/auth/user';
+
+  constructor(private http: HttpClient) {}
+
+  getUsers(pageIndex: number, order: string): Observable<UserPaginationResult> {
+      return this.http
+        .get<UserPaginationResult>(
+          this.httpRoute +
+            `?pageIndex=${pageIndex}&&itemsPerPage=20&&order=${order}`
+        )
+      .pipe(first());
+  }
+
+  createUser(createUserData: {
+      name: string;
+      username: string;
+      password: string;
+      roles: BasicRole[];
+    }) {
+      return this.http.post(this.httpRoute, createUserData).pipe(first());
+  }
+
+  updateUser(subjectId: number, updateBody: UserUpdateBody) {
+      return this.http
+        .put(`${this.httpRoute}/${subjectId}`, updateBody)
+        .pipe(first());
+  }
+
+  deleteUser(subjectId: number) {
+    return this.http.delete(`${this.httpRoute}/${subjectId}`).pipe(first());
+  }
+
+  updateUserRoles(
+      userId: number,
+      roles: BasicRole[],
+      originalRolesList: BasicRole[]
+  ) {
+  return this.http
+      .put(`${this.httpRoute}/${userId}/role`, { roles, originalRolesList })
+      .pipe(first());
+  }
+}
+
+interface PaginationUserContent {
+    items: User[];
+    pageIndex: number;
+    itemsPerPage: number;
+    totalItems: number;
+    totalPages: number;
+  }
+  
+interface UserPaginationResult {
+    message: string;
+    code: number;
+    content?: PaginationUserContent;
+}
+
+export interface UserUpdateBody {
+  name: string;
+}
+
+export interface BasicResource {
+  id: number;
+  applicationResourceName: string;
+  allowed: string[];
+}
+
+interface RoleUser {
+  id: number;
+  identifier: string;
+  resources: BasicResource[];
+}
+export interface User {
+  id: number;
+  subjectId: number;
+  description: string;
+  name: string;
+  username: string;
+  roles: RoleUser[];
+}

--- a/src/app/dashboard/services/user.service.ts
+++ b/src/app/dashboard/services/user.service.ts
@@ -50,6 +50,27 @@ export class UserService {
       .put(`${this.httpRoute}/${userId}/role`, { roles, originalRolesList })
       .pipe(first());
   }
+
+  getUserProfile(): Observable<UserProfileResult> {
+    return this.http
+      .get<UserProfileResult>(`${this.httpRoute}/profile/me`)
+      .pipe(first());
+  }
+
+  updatePassword(userId: number, newPassword: string, oldPassword: string) {
+    return this.http
+      .put(`${this.httpRoute}/${userId}/password`, {
+        newPassword,
+        oldPassword,
+      })
+      .pipe(first());
+  }
+}
+
+interface UserProfileResult {
+  message: string;
+  code: number;
+  content?: User;
 }
 
 interface PaginationUserContent {


### PR DESCRIPTION
## Description
```
Move modules from [node-boot-oauth2-ui](https://github.com/usil/nodeboot-oauth2-ui-starter) library to the web base
```

Due to the complexity imposed by angular to create libraries or npm packages, we are moving all the forms from the node-boot-oauth2-ui library into the source code base of this web

## :beetle: Bugs
```
- none
```

## :rocket: Features

- [#25 ](https://github.com/usil/eventhos-web/issues/25)